### PR TITLE
v1 refactors and model features

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,6 @@
 
 const Objection = require('objection');
 const Knex = require('knex');
-
 const Path = require('path');
 const Hoek = require('hoek');
 const Joi = require('joi');
@@ -29,7 +28,7 @@ exports.register = (server, options, next) => {
         rootState.collector = {
             models: {},
             teardownOnStop: null, // Not set, effectively defaults true
-            knexGroups: {}
+            knexGroups: []
         };
 
         // Here's the ORM!
@@ -37,8 +36,8 @@ exports.register = (server, options, next) => {
         server.decorate('server', 'schwifty', internals.schwifty);
         server.decorate('server', 'models', internals.models((ctx) => ctx, 'realm'));
         server.decorate('request', 'models', internals.models((ctx) => ctx.server, 'route.realm'));
-        server.decorate('server', 'knex', internals.knex((ctx) => ctx, 'realm'));
-        server.decorate('request', 'knex', internals.knex((ctx) => ctx.server, 'route.realm'));
+        server.decorate('server', 'knex', internals.knex('realm'));
+        server.decorate('request', 'knex', internals.knex('route.realm'));
         server.ext('onPreStart', internals.initialize);
         server.ext('onPostStop', internals.stop);
 
@@ -90,14 +89,12 @@ internals.initialize = function (server, next) {
 
     const rootCollector = internals.state(server.root).collector;
 
-    Object.keys(rootCollector.knexGroups).forEach((key) => {
+    rootCollector.knexGroups.forEach((knexGroup) => {
 
-        const knexGroup = rootCollector.knexGroups[key];
         const models = knexGroup.models;
 
         models.forEach((modelName) => {
 
-            modelName = modelName.toLowerCase();
             const model = rootCollector.models[modelName];
             const modelKnexed = model.bindKnex(knexGroup.knex);
             rootCollector.models[modelName] = modelKnexed;
@@ -147,19 +144,13 @@ internals.schwifty = function (config) {
 
     modelIds.forEach((id, index) => {
 
-        // Classnames are often first-capital
-        id = id.toLowerCase();
-        Hoek.assert(!rootCollector.models[id], `Model definition with tableName "${id}" has already been registered.`);
-        rootCollector.models[id] = userConfig.models[index];
+        Hoek.assert(!rootCollector.models[id], `Model definition with name ${JSON.stringify(id)} has already been registered.`);
 
-        Hoek.assert(rootCollector.models[id].tableName, 'Model definition must have "static get tableName(){ return \'myTableName\' }"');
+        rootCollector.models[id] = userConfig.models[index];
     });
 
-
-    /*
-        A knexGroup is a knexConfig db connection plus the models that are going there,
-        the default is the root server's connection.
-    */
+    // A knexGroup is a knexConfig db connection plus the models that are going there,
+    // the default is the root server's connection.
     const knexGroup = {
         models: [],
         knex: {}
@@ -168,19 +159,20 @@ internals.schwifty = function (config) {
     const state = internals.state(this);
 
     if (userConfig.knexConfig && typeof userConfig.knexConfig !== 'undefined') {
-        Hoek.assert(typeof state.knexGroupId === 'undefined', 'Only one knexConfig allowed per server or plugin');
+        Hoek.assert(typeof state.knexGroup === 'undefined', 'Only one knexConfig allowed per server or plugin');
     }
 
     // Check if this state already has a knexGroup associated with it
-    if (state.knexGroupId) {
 
-        // The knexGroupId exists so add to models already there, also no need to continue so return here
-        const models = rootCollector.knexGroups[state.knexGroupId].models;
-        rootCollector.knexGroups[state.knexGroupId].models = models.concat(modelIds);
+    if (state.knexGroup) {
+
+        // The knexGroup exists so add to models already there, also no need to continue so return here
+        state.knexGroup.models = state.knexGroup.models.concat(modelIds);
         return;
     }
 
     // Handle the knex instance
+
     if (userConfig.knexConfig) {
 
         const knexInstance = Knex(userConfig.knexConfig);
@@ -193,21 +185,18 @@ internals.schwifty = function (config) {
         }
     }
     else {
-
         // By default the knex connection is the root server's.
         Hoek.assert(internals.state(this.root).knex, 'Must have root server knexConfig set before adding more models');
         knexGroup.knex = internals.state(this.root).knex;
     }
 
-
     // Now keep track of which plugins have which knex connections
     // modelIds is an array
     knexGroup.models = modelIds;
 
-    const randId = internals.randomId();
-    state.knexGroupId = randId;
+    state.knexGroup = knexGroup;
 
-    rootCollector.knexGroups[randId] = knexGroup;
+    rootCollector.knexGroups.push(knexGroup);
 };
 
 internals.models = (serverFrom, realmPath) => {
@@ -220,17 +209,17 @@ internals.models = (serverFrom, realmPath) => {
             return {};
         }
 
-        const knexGroupId = Hoek.reach(this, `${realmPath}.plugins.schwifty.knexGroupId`);
+        const knexGroup = Hoek.reach(this, `${realmPath}.plugins.schwifty.knexGroup`);
 
-        if (all || !knexGroupId) {
+        if (all || !knexGroup) {
             return rootCollector.models;
         }
 
         const modelObj = {};
-        const models = rootCollector.knexGroups[knexGroupId].models;
+        const models = knexGroup.models;
 
         for (let i = 0; i < models.length; ++i) {
-            const modelName = models[i].toLowerCase();
+            const modelName = models[i];
             modelObj[modelName] = rootCollector.models[modelName];
         }
 
@@ -238,13 +227,11 @@ internals.models = (serverFrom, realmPath) => {
     };
 };
 
-internals.knex = function (serverFrom, realmPath) {
+internals.knex = (realmPath) => {
 
     return function () {
 
-        const rootCollector = internals.state(serverFrom(this).root).collector;
-        const knexGroupId = Hoek.reach(this, `${realmPath}.plugins.schwifty.knexGroupId`);
-        return rootCollector.knexGroups[knexGroupId].knex;
+        return Hoek.reach(this, `${realmPath}.plugins.schwifty.knexGroup.knex`);
     };
 };
 
@@ -267,9 +254,9 @@ internals.stop = function (server, next) {
 
     const knexConnections = [rootKnex];
 
-    Object.keys(rootCollector.knexGroups).forEach((key) => {
+    rootCollector.knexGroups.forEach((knexGroup) => {
 
-        const knexConn = rootCollector.knexGroups[key].knex;
+        const knexConn = knexGroup.knex;
 
         if (knexConn !== rootKnex) {
             knexConnections.push(knexConn);
@@ -277,17 +264,6 @@ internals.stop = function (server, next) {
     });
 
     Items.parallel(knexConnections, (item, nxt) => item.destroy(nxt), next);
-};
-
-internals.randomId = () => {
-
-    // new Date().getTime() with 2 random letters on the end should be sufficient
-    const alph = 'abcdefghijklmnopqrstuvwxyz';
-    let randId = new Date().getTime();
-    randId += alph.charAt(Math.floor(Math.random() * alph.length));
-    randId += alph.charAt(Math.floor(Math.random() * alph.length));
-
-    return randId;
 };
 
 exports.Model = class SchwiftyModel extends Objection.Model {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,13 +1,13 @@
 'use strict';
 
+const Path = require('path');
 const Objection = require('objection');
 const Knex = require('knex');
-const Path = require('path');
 const Hoek = require('hoek');
 const Joi = require('joi');
+const Items = require('items');
 const Schema = require('./schema');
 const Package = require('../package.json');
-const Items = require('items');
 
 const internals = {};
 
@@ -16,12 +16,6 @@ exports.register = (server, options, next) => {
     Joi.assert(options, Schema.plugin, 'Bad plugin options passed to schwifty.');
 
     const rootState = internals.state(server.root);
-
-    let userOptions = Hoek.shallow(options);
-
-    if (options.models) {
-        userOptions.models = options.models;
-    }
 
     if (!rootState.setup) {
 
@@ -53,8 +47,8 @@ exports.register = (server, options, next) => {
         rootCollector.teardownOnStop = options.teardownOnStop;
     }
 
-    userOptions = internals.registrationConfig(userOptions);
-    server.root.schwifty(userOptions);
+    const config = internals.registrationConfig(options);
+    server.root.schwifty(config);
 
     return next();
 };
@@ -153,7 +147,7 @@ internals.schwifty = function (config) {
     // the default is the root server's connection.
     const knexGroup = {
         models: [],
-        knex: {}
+        knex: null
     };
 
     const state = internals.state(this);
@@ -268,6 +262,50 @@ internals.stop = function (server, next) {
 
 exports.Model = class SchwiftyModel extends Objection.Model {
 
+    static get joiSchema() {}
+
+    // Caches schema, with and without optional keys
+    // Will create _schemaMemo and _optionalSchemaMemo properties
+    static getJoiSchema(patch) {
+
+        const schema = this._schemaMemo = this._schemaMemo || this.joiSchema;
+
+        if (patch) {
+            const patchSchema = this._patchSchemaMemo = this._patchSchemaMemo || internals.patchSchema(schema);
+            return patchSchema;
+        }
+
+        return schema;
+    }
+
+    // Will create _jsonAttributesMemo properties
+    static get jsonAttributes() {
+
+        if (this._jsonAttributesMemo) {
+            return this._jsonAttributesMemo;
+        }
+
+        const joiSchema = this.getJoiSchema();
+
+        if (!joiSchema) {
+            return null;
+        }
+
+        const schemaKeyDescs = joiSchema.describe().children || {};
+
+        const jsonAttributes = Object.keys(schemaKeyDescs).filter((field) => {
+
+            const type = schemaKeyDescs[field].type;
+
+            // These are the joi types we want to be parsed/serialized as json
+            return (type === 'array') || (type === 'object');
+        });
+
+        this._jsonAttributesMemo = jsonAttributes;
+
+        return jsonAttributes;
+    }
+
     static parseJoiValidationError(validation) {
 
         return validation.error.details;
@@ -278,7 +316,7 @@ exports.Model = class SchwiftyModel extends Objection.Model {
         json = json || this.$parseJson(this.$toJson(true));
         options = options || {};
 
-        let joiSchema = this.constructor.schema;
+        let joiSchema = this.constructor.getJoiSchema(options.patch);
 
         if (!joiSchema || options.skipValidation) {
             return json;
@@ -300,4 +338,21 @@ exports.Model = class SchwiftyModel extends Objection.Model {
 
         return json;
     }
+};
+
+internals.patchSchema = (schema) => {
+
+    if (!schema) {
+        return;
+    }
+
+    const keys = Object.keys(schema.describe().children || {});
+
+    // Make all keys optional, do not enforce defaults
+
+    if (keys.length) {
+        schema = schema.optionalKeys(keys);
+    }
+
+    return schema.options({ noDefaults: true });
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const Objection = require('objection');
-const Model = Objection.Model;
 const Knex = require('knex');
 
 const Path = require('path');
@@ -291,52 +290,38 @@ internals.randomId = () => {
     return randId;
 };
 
-exports.Model = class SchwiftyModel extends Model {
+exports.Model = class SchwiftyModel extends Objection.Model {
 
-    // $beforeInsert() {
-    //   this.createdAt = new Date().toISOString();
-    // };
+    static parseJoiValidationError(validation) {
 
-    // $beforeUpdate() {
-    //   this.updatedAt = new Date().toISOString();
-    // };
-
-    static parseValidationError(err) {
-
-        // Implement this if you'd like to further parse Joi's error.details
-        return err;
+        return validation.error.details;
     }
 
-    $validate(json, options) {
+    $validate(json, options) { // Note, in objection v0.7.x there is a new Validator interface
 
-        if (!json) {
-            // eslint complains about setting json to 'this'
-            const self = this;
-            json = self;
-        }
+        json = json || this.$parseJson(this.$toJson(true));
+        options = options || {};
 
-        if (!options) {
-            options = {};
-        }
-
-        const ModelClass = this.constructor;
-
-        const joiSchema = ModelClass.schema;
+        let joiSchema = this.constructor.schema;
 
         if (!joiSchema || options.skipValidation) {
             return json;
         }
 
-        let validation = Joi.validate(json, joiSchema);
+        // Allow modification of schema, setting of options, etc.
+        joiSchema = this.$beforeValidate(joiSchema, json, options);
+
+        const validation = joiSchema.validate(json);
 
         if (validation.error) {
-
-            throw new Objection.ValidationError(SchwiftyModel.parseValidationError(validation.error.details));
+            const errors = SchwiftyModel.parseJoiValidationError(validation);
+            throw new Objection.ValidationError(errors);
         }
 
-        validation = validation.value;
-        this.$afterValidate(validation, options);
+        json = validation.value;
 
-        return validation;
+        this.$afterValidate(json, options);
+
+        return json;
     }
 };

--- a/test/index.js
+++ b/test/index.js
@@ -1116,7 +1116,7 @@ describe('Schwifty', () => {
                 done();
             });
 
-            it('skips validation when missing model is missing joiSchema.', (done) => {
+            it('skips validation if model is missing joiSchema.', (done) => {
 
                 const anythingGoes = new Schwifty.Model();
 
@@ -1126,20 +1126,6 @@ describe('Schwifty', () => {
                 };
 
                 expect(anythingGoes.$validate(whateverSchema)).to.equal(whateverSchema);
-
-                done();
-            });
-
-            it('skips validation if `skipValidation` option is passed to $validate().', (done) => {
-
-                const chompy = new ZombieModel();
-
-                const whateverSchema = {
-                    anything: 'goes',
-                    whatever: 8
-                };
-
-                expect(chompy.$validate(whateverSchema, { skipValidation: true })).to.equal(whateverSchema);
 
                 done();
             });

--- a/test/index.js
+++ b/test/index.js
@@ -87,14 +87,14 @@ describe('Schwifty', () => {
         getServer(config, (err, server) => {
 
             expect(err).to.not.exist();
-            expect(server.models().dog.$$knex).to.not.exist();
-            expect(server.models().person.$$knex).to.not.exist();
+            expect(server.models().Dog.$$knex).to.not.exist();
+            expect(server.models().Person.$$knex).to.not.exist();
 
             server.initialize((err) => {
 
                 expect(err).to.not.exist();
-                expect(server.models().dog.$$knex).to.exist();
-                expect(server.models().person.$$knex).to.exist();
+                expect(server.models().Dog.$$knex).to.exist();
+                expect(server.models().Person.$$knex).to.exist();
                 expect(server.models()).to.exist();
                 done();
             });
@@ -313,10 +313,10 @@ describe('Schwifty', () => {
 
                 // Ensure all models got added
                 expect(Object.keys(server.models())).to.only.contain([
-                    'dog',
-                    'person',
-                    'movie',
-                    'zombie'
+                    'Dog',
+                    'Person',
+                    'Movie',
+                    'Zombie'
                 ]);
 
                 done();
@@ -337,8 +337,8 @@ describe('Schwifty', () => {
 
                 const models = server.models();
 
-                expect(models.dog).to.exist();
-                expect(models.person).to.exist();
+                expect(models.Dog).to.exist();
+                expect(models.Person).to.exist();
 
                 done();
             });
@@ -355,8 +355,8 @@ describe('Schwifty', () => {
                 expect(err).to.not.exist();
 
                 const models = server.models();
-                expect(models.dog).to.exist();
-                expect(models.person).to.exist();
+                expect(models.Dog).to.exist();
+                expect(models.Person).to.exist();
 
                 done();
             });
@@ -375,8 +375,8 @@ describe('Schwifty', () => {
                 expect(err).to.not.exist();
 
                 const models = server.models();
-                expect(models.dog).to.exist();
-                expect(models.person).to.exist();
+                expect(models.Dog).to.exist();
+                expect(models.Person).to.exist();
 
                 done();
             });
@@ -467,10 +467,10 @@ describe('Schwifty', () => {
                         // Grab all models across plugins by passing true here:
                         const models = server.models(true);
 
-                        expect(models.dog.tableName).to.equal('Dog');
-                        expect(models.person.tableName).to.equal('Person');
-                        expect(models.zombie.tableName).to.equal('Zombie');
-                        expect(models.movie.tableName).to.equal('Movie');
+                        expect(models.Dog.tableName).to.equal('Dog');
+                        expect(models.Person.tableName).to.equal('Person');
+                        expect(models.Zombie.tableName).to.equal('Zombie');
+                        expect(models.Movie.tableName).to.equal('Movie');
 
                         done();
                     });
@@ -485,7 +485,7 @@ describe('Schwifty', () => {
                 expect(err).to.not.exist();
 
                 const rootState = state(server.root);
-                expect(Object.keys(rootState.collector.models)).to.equal(['dog', 'person']);
+                expect(Object.keys(rootState.collector.models)).to.equal(['Dog', 'Person']);
 
                 const plugin = (srv, opts, next) => {
 
@@ -510,13 +510,13 @@ describe('Schwifty', () => {
 
                         expect(err).to.not.exist();
 
-                        expect(rootState.collector.knexGroups[server.app.myState.knexGroupId].models).to.equal(['Movie', 'Zombie']);
+                        expect(server.app.myState.knexGroup.models).to.equal(['Movie', 'Zombie']);
 
                         expect(Object.keys(rootState.collector.models)).to.only.contain([
-                            'dog',
-                            'person',
-                            'movie',
-                            'zombie'
+                            'Dog',
+                            'Person',
+                            'Movie',
+                            'Zombie'
                         ]);
 
                         done();
@@ -544,7 +544,7 @@ describe('Schwifty', () => {
                     expect(err).to.not.exist();
 
                     const collector = state(server).collector;
-                    expect(collector.models.zombie).to.exist();
+                    expect(collector.models.Zombie).to.exist();
 
                     done();
                 });
@@ -606,7 +606,7 @@ describe('Schwifty', () => {
 
                         throw new Error('Should not make it here.');
                     });
-                }).to.throw('Model definition with tableName "dog" has already been registered.');
+                }).to.throw('Model definition with name "Dog" has already been registered.');
 
                 done();
             });
@@ -739,74 +739,6 @@ describe('Schwifty', () => {
                 });
             });
         });
-
-    //     it('keeps models seperated into correct `knexGroups`', (done) => {
-
-    //         const createTablesInDb = (knexGroup, rootState, cb) => {
-
-    //             Items.parallel(knexGroup.models, (modelName, next) => {
-
-    //                 knexGroup.knex.schema.createTableIfNotExists(modelName, (table) => {
-
-    //                     table.integer('id').primary();
-    //                 }).then(next);
-    //             }, (err) => {
-
-    //                 expect(err).to.equal([]);
-    //                 cb();
-    //             });
-    //         };
-
-    //         getServer(getOptions(true), (err, server) => {
-
-    //             expect(err).to.not.exist();
-
-
-    //             const plugin = (srv, opts, next) => {
-
-    //                 srv.schwifty({
-    //                     models: require('./models-movie').concat(require('./models-zombie')),
-    //                     knexConfig: {
-    //                         client: 'sqlite3',
-    //                         connection: {
-    //                             filename: 'mydb.sqlite'
-    //                         },
-    //                         useNullAsDefault: true
-    //                     }
-    //                 });
-
-    //                 createTablesInDb(state(srv.root).collector.knexGroups[state(srv).knexGroupId], state(srv), () => {
-
-    //                     srv.app.myState = state(srv);
-    //                     next();
-    //                 });
-    //             };
-
-    //             plugin.attributes = { name: 'my-plugin' };
-
-    //             server.register(plugin, (err) => {
-
-    //                 expect(err).to.not.exist();
-
-    //                 server.initialize((err) => {
-
-    //                     expect(err).to.not.exist();
-
-    //                     expect(rootState.collector.knexGroups[server.app.myState.knexGroupId].models).to.equal(['movie', 'zombie']);
-
-    //                     expect(Object.keys(rootState.collector.models)).to.only.contain([
-    //                         'dog',
-    //                         'person',
-    //                         'movie',
-    //                         'zombie'
-    //                     ]);
-
-    //                     done();
-    //                 });
-    //             });
-    //         });
-    //     });
-
     });
 
     describe('request.models() and server.models() decorations', () => {
@@ -857,10 +789,7 @@ describe('Schwifty', () => {
 
                 });
 
-                const knexGroupId = state(server).knexGroupId;
-
-                expect(knexGroupId).to.exist();
-                expect(state(server.root).collector.knexGroups[knexGroupId].models).to.equal([]);
+                expect(state(server).knexGroup.models).to.equal([]);
 
                 expect(server.models()).to.equal({});
                 expect(server.models(true)).to.equal({});
@@ -924,8 +853,8 @@ describe('Schwifty', () => {
 
                         const models = request.models();
                         expect(models).to.have.length(2);
-                        expect(models.dog.tableName).to.equal('Dog');
-                        expect(models.person.tableName).to.equal('Person');
+                        expect(models.Dog.tableName).to.equal('Dog');
+                        expect(models.Person.tableName).to.equal('Person');
                         reply({ ok: 'root' });
                     }
                 });
@@ -933,8 +862,8 @@ describe('Schwifty', () => {
 
                     const models = server.models();
                     expect(models).to.have.length(2);
-                    expect(models.dog.tableName).to.equal('Dog');
-                    expect(models.person.tableName).to.equal('Person');
+                    expect(models.Dog.tableName).to.equal('Dog');
+                    expect(models.Person.tableName).to.equal('Person');
                     nxt();
                 });
 
@@ -948,7 +877,7 @@ describe('Schwifty', () => {
 
                             const models = request.models();
                             expect(models).to.have.length(1);
-                            expect(models.movie.tableName).to.equal('Movie');
+                            expect(models.Movie.tableName).to.equal('Movie');
                             reply({ ok: 'plugin' });
                         }
                     });
@@ -956,7 +885,7 @@ describe('Schwifty', () => {
 
                         const models = srv.models();
                         expect(models).to.have.length(1);
-                        expect(models.movie.tableName).to.equal('Movie');
+                        expect(models.Movie.tableName).to.equal('Movie');
                         nxt();
                     });
                     next();
@@ -1049,9 +978,9 @@ describe('Schwifty', () => {
 
                         const models = request.models(true);
                         expect(models).to.have.length(3);
-                        expect(models.dog.tableName).to.equal('Dog');
-                        expect(models.person.tableName).to.equal('Person');
-                        expect(models.zombie.tableName).to.equal('Zombie');
+                        expect(models.Dog.tableName).to.equal('Dog');
+                        expect(models.Person.tableName).to.equal('Person');
+                        expect(models.Zombie.tableName).to.equal('Zombie');
                         reply({ ok: 'root' });
                     }
                 });
@@ -1059,9 +988,9 @@ describe('Schwifty', () => {
 
                     const models = server.models(true);
                     expect(models).to.have.length(3);
-                    expect(models.dog.tableName).to.equal('Dog');
-                    expect(models.person.tableName).to.equal('Person');
-                    expect(models.zombie.tableName).to.equal('Zombie');
+                    expect(models.Dog.tableName).to.equal('Dog');
+                    expect(models.Person.tableName).to.equal('Person');
+                    expect(models.Zombie.tableName).to.equal('Zombie');
                     nxt();
                 });
 
@@ -1075,9 +1004,9 @@ describe('Schwifty', () => {
 
                             const models = request.models(true);
                             expect(models).to.have.length(3);
-                            expect(models.dog.tableName).to.equal('Dog');
-                            expect(models.person.tableName).to.equal('Person');
-                            expect(models.zombie.tableName).to.equal('Zombie');
+                            expect(models.Dog.tableName).to.equal('Dog');
+                            expect(models.Person.tableName).to.equal('Person');
+                            expect(models.Zombie.tableName).to.equal('Zombie');
                             reply({ ok: 'plugin' });
                         }
                     });
@@ -1085,9 +1014,9 @@ describe('Schwifty', () => {
 
                         const models = srv.models(true);
                         expect(models).to.have.length(3);
-                        expect(models.dog.tableName).to.equal('Dog');
-                        expect(models.person.tableName).to.equal('Person');
-                        expect(models.zombie.tableName).to.equal('Zombie');
+                        expect(models.Dog.tableName).to.equal('Dog');
+                        expect(models.Person.tableName).to.equal('Person');
+                        expect(models.Zombie.tableName).to.equal('Zombie');
                         nxt();
                     });
                     next();
@@ -1130,7 +1059,7 @@ describe('Schwifty', () => {
 
                 expect(err).not.to.exist();
 
-                const ZombieClass = server.models().zombie;
+                const ZombieClass = server.models().Zombie;
                 const chompy = new ZombieClass();
 
                 const validateRes = chompy.$validate({
@@ -1157,7 +1086,7 @@ describe('Schwifty', () => {
 
                 expect(err).not.to.exist();
 
-                const ZombieClass = server.models().zombie;
+                const ZombieClass = server.models().Zombie;
                 const chompy = new ZombieClass();
                 chompy.firstName = 'chompy';
 
@@ -1185,7 +1114,7 @@ describe('Schwifty', () => {
 
                 expect(err).not.to.exist();
 
-                const ZombieClass = server.models().zombie;
+                const ZombieClass = server.models().Zombie;
                 const chompy = new ZombieClass();
 
                 expect(() => {
@@ -1208,7 +1137,7 @@ describe('Schwifty', () => {
 
                 expect(err).not.to.exist();
 
-                const ZombieClass = server.models().zombie;
+                const ZombieClass = server.models().Zombie;
                 const chompy = new ZombieClass();
 
                 expect(() => {
@@ -1240,7 +1169,7 @@ describe('Schwifty', () => {
 
                 expect(err).not.to.exist();
 
-                const NoSchemaClass = server.models().noschema;
+                const NoSchemaClass = server.models().NoSchema;
 
                 const anythingGoes = new NoSchemaClass();
 
@@ -1264,7 +1193,7 @@ describe('Schwifty', () => {
 
                 expect(err).not.to.exist();
 
-                const ZombieClass = server.models().zombie;
+                const ZombieClass = server.models().Zombie;
                 const chompy = new ZombieClass();
 
                 const whateverSchema = {

--- a/test/models-movie.js
+++ b/test/models-movie.js
@@ -3,25 +3,18 @@
 const Joi = require('joi');
 const Model = require('..').Model;
 
-module.exports = [
+module.exports = class Movie extends Model {
 
-    class Movie extends Model {
+    static get tableName() {
 
-        static get tableName() {
-
-            return 'Movie';
-        }
-
-        static get schema() {
-
-            return Joi.object({
-
-                // Note: in these schemas, whatever is required() is also required when
-                // querying for it FROM the database as well.
-
-                title: Joi.string(),
-                subTitle: Joi.string()
-            });
-        }
+        return 'Movie';
     }
-];
+
+    static get joiSchema() {
+
+        return Joi.object({
+            title: Joi.string(),
+            subTitle: Joi.string()
+        });
+    }
+};

--- a/test/models-zombie.js
+++ b/test/models-zombie.js
@@ -3,37 +3,25 @@
 const Joi = require('joi');
 const Model = require('..').Model;
 
-module.exports = [
+module.exports = class Zombie extends Model {
 
-    class Zombie extends Model {
+    static get tableName() {
 
-        static get tableName() {
-
-            return 'Zombie';
-        }
-
-        static get schema() {
-
-            return Joi.object({
-
-                /*
-                    Note: in these schemas, whatever is required() is also required when
-                    querying for it FROM the database as well.
-                */
-
-                firstName: Joi.string().required().max(255),
-                lastName: Joi.string(),
-
-                age: Joi.number().integer(),
-
-                address: Joi.object({
-                    street: Joi.string(),
-                    city: Joi.string(),
-                    zipCode: Joi.string()
-                }),
-
-                favoriteFood: Joi.string().default('Tasty brains')
-            });
-        }
+        return 'Zombie';
     }
-];
+
+    static get joiSchema() {
+
+        return Joi.object({
+            firstName: Joi.string().required().max(255),
+            lastName: Joi.string(),
+            age: Joi.number().integer(),
+            address: Joi.object({
+                street: Joi.string(),
+                city: Joi.string(),
+                zipCode: Joi.string()
+            }),
+            favoriteFood: Joi.string().default('Tasty brains')
+        });
+    }
+};

--- a/test/models.js
+++ b/test/models.js
@@ -4,7 +4,6 @@ const Joi = require('joi');
 const Model = require('..').Model;
 
 module.exports = [
-
     class Dog extends Model {
 
         static get tableName() {
@@ -12,18 +11,9 @@ module.exports = [
             return 'Dog';
         }
 
-        static customFunc() {
-
-            return 'Custom func called from Dog!';
-        }
-
-        static get schema() {
+        static get joiSchema() {
 
             return Joi.object({
-
-                // Note: in these schemas, whatever is required() is also required when
-                // querying for it FROM the database as well.
-
                 favoriteToy: Joi.string(),
                 name: Joi.number(),
                 ownerId: Joi.number().integer()
@@ -37,28 +27,12 @@ module.exports = [
             return 'Person';
         }
 
-        static customFunc() {
-
-            return 'Custom func called from Person!';
-        }
-
-        upsert(model) {
-
-            if (model.id) {
-                return this.update(model).where('id', model.id);
-            }
-
-            return this.insert(model);
-        }
-
-        static get schema() {
+        static get joiSchema() {
 
             return Joi.object({
                 firstName: Joi.string().required().max(255),
                 lastName: Joi.number(),
-
                 age: Joi.number().integer(),
-
                 address: Joi.object({
                     street: Joi.string(),
                     city: Joi.string(),

--- a/test/models.js
+++ b/test/models.js
@@ -54,12 +54,6 @@ module.exports = [
         static get schema() {
 
             return Joi.object({
-
-                /*
-                    Note: in these schemas, whatever is required() is also required when
-                    querying for it FROM the database as well.
-                */
-
                 firstName: Joi.string().required().max(255),
                 lastName: Joi.number(),
 


### PR DESCRIPTION
This includes a fair amount of cleanup/refactoring.  It also includes some missing model features covered by #4 and #5– using the joi schema to determine the attributes that should be serialized as JSON, and adjusting the joi schema so that it's suitable for `patch()`es (should not apply default values or enforce required fields).  Here's a summary,

1. Refactor out arbitrary random-id-ing of "knex-groups."  This was a big one!  I think we can further refactor the internal plugin state to be more ergonomic, and possibly more flexible (e.g. if in the future models within a single plugin might have different knex instances).
2. Handle memoization of joi schema (so that we don't compile joi schemas all the dang time... it's expensive).
3. Simplify model tests by not involving hapi when it's not necessary.
4. Support correct validation of `patch()`es (#4), with tests.
5. Support computing of (memoized) `jsonAttributes` (#5) based upon joi schema, with tests.
6. Do not rely on the internal version of joi for model validation.
7. No longer enforce lowercase model names.  PascalCase is actually desirable because our models are classes.
8. Miscellaneous cleanup and removing of dead/commented code.