### PR TITLE
Implement migrator

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,7 @@ const Knex = require('knex');
 const Hoek = require('hoek');
 const Joi = require('joi');
 const Items = require('items');
+const Migrator = require('./migrator');
 const Schema = require('./schema');
 const Package = require('../package.json');
 
@@ -22,6 +23,7 @@ exports.register = (server, options, next) => {
         rootState.collector = {
             models: {},
             teardownOnStop: null, // Not set, effectively defaults true
+            migrateOnStart: null, // ditto
             knexGroups: []
         };
 
@@ -47,6 +49,13 @@ exports.register = (server, options, next) => {
         rootCollector.teardownOnStop = options.teardownOnStop;
     }
 
+    // Decide whether server start should perform migrations
+
+    if (typeof options.migrateOnStart !== 'undefined') {
+        Hoek.assert(rootCollector.migrateOnStart === null, 'Schwifty\'s migrateOnStart option can only be specified once.');
+        rootCollector.migrateOnStart = options.migrateOnStart;
+    }
+
     const config = internals.registrationConfig(options);
     server.root.schwifty(config);
 
@@ -64,6 +73,7 @@ internals.registrationConfig = (options) => {
     const config = Hoek.shallow(options);
 
     delete config.teardownOnStop;
+    delete config.migrateOnStart;
 
     // Resolve models
 
@@ -81,8 +91,9 @@ internals.registrationConfig = (options) => {
 
 internals.initialize = (server, next) => {
 
-    const collector = internals.state(server.root).collector;
-    const rootKnex = Hoek.reach(collector, 'knexGroup.knex') || null;
+    const rootState = internals.state(server.root);
+    const collector = rootState.collector;
+    const rootKnex = Hoek.reach(rootState, 'knexGroup.knex') || null;
 
     collector.knexGroups.forEach((knexGroup) => {
 
@@ -97,7 +108,11 @@ internals.initialize = (server, next) => {
         });
     });
 
-    return next();
+    if (!collector.migrateOnStart) {
+        return next();
+    }
+
+    Migrator.migrate(collector.knexGroups, rootKnex, next);
 };
 
 internals.schwifty = function (config) {
@@ -121,10 +136,18 @@ internals.schwifty = function (config) {
     if (!state.knexGroup) {
         state.knexGroup = {
             models: [],
+            migrationsDir: null,
             knex: null
         };
 
         collector.knexGroups.push(state.knexGroup);
+    }
+
+    // Set plugin's migrations dir if available and allowed
+
+    if (typeof config.migrationsDir !== 'undefined') {
+        Hoek.assert(state.knexGroup.migrationsDir === null, 'Schwifty\'s migrationsDir plugin option can only be specified once per plugin.');
+        state.knexGroup.migrationsDir = config.migrationsDir;
     }
 
     // Collect models ensuring no dupes

--- a/lib/index.js
+++ b/lib/index.js
@@ -23,7 +23,7 @@ exports.register = (server, options, next) => {
         rootState.collector = {
             models: {},
             teardownOnStop: null, // Not set, effectively defaults true
-            migrateOnStart: null, // ditto
+            migrateOnStart: null, // Not set, effectively defaults false
             knexGroups: []
         };
 
@@ -112,7 +112,9 @@ internals.initialize = (server, next) => {
         return next();
     }
 
-    Migrator.migrate(collector.knexGroups, rootKnex, next);
+    const rollback = (collector.migrateOnStart === 'rollback');
+
+    Migrator.migrate(collector.knexGroups, rootKnex, rollback, next);
 };
 
 internals.schwifty = function (config) {

--- a/lib/migrator.js
+++ b/lib/migrator.js
@@ -12,7 +12,7 @@ exports.migrate = (knexGroups, defaultKnex, cb) => {
 
     for (let i = 0; i < knexGroups.length; ++i) {
         const knexGroup = knexGroups[i];
-        const migrationsDir = knexGroup.migrationsDirectory;
+        const migrationsDir = knexGroup.migrationsDir;
 
         if (!migrationsDir) {
             continue;
@@ -28,12 +28,12 @@ exports.migrate = (knexGroups, defaultKnex, cb) => {
 
         const migrationsDirs = knexMigrations.get(knex);
 
-        // Relativize and normalize, just how knex likes it
-        const relMigrationsDir = Path.isAbsolute(migrationsDir) ?
-                                    Path.relative(process.cwd(), migrationsDir) :
-                                    Path.normalize(migrationsDir);
+        // Absolutize and normalize
+        const absMigrationsDir = Path.isAbsolute(migrationsDir) ?
+                                    Path.normalize(migrationsDir) :
+                                    Path.join(process.cwd(), migrationsDir);
 
-        migrationDirs[relMigrationsDir] = true;
+        migrationsDirs[absMigrationsDir] = true;
     }
 
     // For each knex instance
@@ -45,7 +45,17 @@ exports.migrate = (knexGroups, defaultKnex, cb) => {
 
         // Get a temp directory
 
-        Tmp.file((err, tmpPath) => {
+        Tmp.dir({ unsafeCleanup: true }, (err, tmpPath, cleanupTmp) => {
+
+            // Set next migration callback to also perform tmp dir cleanup
+
+            const origNextMigration = nextMigration;
+
+            nextMigration = (err) => {
+
+                cleanupTmp();
+                origNextMigration(err);
+            };
 
             if (err) {
                 return nextMigration(err);
@@ -61,11 +71,12 @@ exports.migrate = (knexGroups, defaultKnex, cb) => {
                         return nextDir(err);
                     }
 
-                    Items.parallel(migrationsFiles, (file, nextFile) => {
+                    Items.parallel(migrationsFiles, (name, nextFile) => {
 
-                        const name = Path.basename(file);
+                        const file = Path.join(migrationsDir, name);
+                        const link = Path.join(tmpPath, name);
 
-                        Fs.symlink(file, Path.join(tmpPath, name), nextFile);
+                        Fs.symlink(file, link, nextFile);
                     }, nextDir);
                 });
             }, (err) => {
@@ -77,7 +88,9 @@ exports.migrate = (knexGroups, defaultKnex, cb) => {
                 // Hand knex the temp directory filled with symlinks
                 // to its migrations and ask it to migrate to latest
 
-                return knex.migrate.latest({ directory: tmpPath }).asCallback(nextMigration);
+                const relMigrationsDir = Path.relative(process.cwd(), tmpPath);
+
+                return knex.migrate.latest({ directory: relMigrationsDir }).asCallback(nextMigration);
             });
         });
     }, cb);

--- a/lib/migrator.js
+++ b/lib/migrator.js
@@ -51,6 +51,11 @@ exports.migrate = (knexGroups, defaultKnex, cb) => {
 
         Tmp.dir({ unsafeCleanup: true }, (err, tmpPath, cleanupTmp) => {
 
+            if (err) {
+                return nextMigration(err);
+            }
+
+
             // Set next migration callback to also perform tmp dir cleanup
 
             const origNextMigration = nextMigration;
@@ -60,10 +65,6 @@ exports.migrate = (knexGroups, defaultKnex, cb) => {
                 cleanupTmp();
                 origNextMigration(err);
             };
-
-            if (err) {
-                return nextMigration(err);
-            }
 
             // Symlink files across all migration directories into that temp directory
 

--- a/lib/migrator.js
+++ b/lib/migrator.js
@@ -10,9 +10,11 @@ const internals = {
     SUPPORTED_EXTENSIONS: ['.co', '.coffee', '.eg', '.iced', '.js', '.litcoffee', '.ls', '.ts'] // from knex
 };
 
-exports.migrate = (knexGroups, defaultKnex, cb) => {
+exports.migrate = (knexGroups, defaultKnex, rollback, cb) => {
 
     const knexMigrations = new Map();
+
+    // Compile migration info per knex instance
 
     for (let i = 0; i < knexGroups.length; ++i) {
         const knexGroup = knexGroups[i];
@@ -54,7 +56,6 @@ exports.migrate = (knexGroups, defaultKnex, cb) => {
             if (err) {
                 return nextMigration(err);
             }
-
 
             // Set next migration callback to also perform tmp dir cleanup
 
@@ -100,8 +101,9 @@ exports.migrate = (knexGroups, defaultKnex, cb) => {
                 // to its migrations and ask it to migrate to latest
 
                 const relMigrationsDir = Path.relative(process.cwd(), tmpPath);
+                const latestOrRollback = rollback ? 'rollback' : 'latest';
 
-                return knex.migrate.latest({ directory: relMigrationsDir }).asCallback(nextMigration);
+                return knex.migrate[latestOrRollback]({ directory: relMigrationsDir }).asCallback(nextMigration);
             });
         });
     }, cb);

--- a/lib/migrator.js
+++ b/lib/migrator.js
@@ -1,0 +1,84 @@
+'use strict';
+
+const Fs = require('fs');
+const Path = require('path');
+const Hoek = require('hoek');
+const Items = require('items');
+const Tmp = require('tmp');
+
+exports.migrate = (knexGroups, defaultKnex, cb) => {
+
+    const knexMigrations = new Map();
+
+    for (let i = 0; i < knexGroups.length; ++i) {
+        const knexGroup = knexGroups[i];
+        const migrationsDir = knexGroup.migrationsDirectory;
+
+        if (!migrationsDir) {
+            continue;
+        }
+
+        const knex = knexGroup.knex || defaultKnex;
+
+        Hoek.assert(knex, 'Cannot specify a migrations directory without an available knex instance.');
+
+        if (!knexMigrations.has(knex)) {
+            knexMigrations.set(knex, {});
+        }
+
+        const migrationsDirs = knexMigrations.get(knex);
+
+        // Relativize and normalize, just how knex likes it
+        const relMigrationsDir = Path.isAbsolute(migrationsDir) ?
+                                    Path.relative(process.cwd(), migrationsDir) :
+                                    Path.normalize(migrationsDir);
+
+        migrationDirs[relMigrationsDir] = true;
+    }
+
+    // For each knex instance
+
+    Items.serial(Array.from(knexMigrations), (migration, nextMigration) => {
+
+        const knex = migration[0];
+        const migrationsDirs = Object.keys(migration[1]);
+
+        // Get a temp directory
+
+        Tmp.file((err, tmpPath) => {
+
+            if (err) {
+                return nextMigration(err);
+            }
+
+            // Symlink files across all migration directories into that temp directory
+
+            Items.parallel(migrationsDirs, (migrationsDir, nextDir) => {
+
+                Fs.readdir(migrationsDir, (err, migrationsFiles) => {
+
+                    if (err) {
+                        return nextDir(err);
+                    }
+
+                    Items.parallel(migrationsFiles, (file, nextFile) => {
+
+                        const name = Path.basename(file);
+
+                        Fs.symlink(file, Path.join(tmpPath, name), nextFile);
+                    }, nextDir);
+                });
+            }, (err) => {
+
+                if (err) {
+                    return nextMigration(err);
+                }
+
+                // Hand knex the temp directory filled with symlinks
+                // to its migrations and ask it to migrate to latest
+
+                return knex.migrate.latest({ directory: tmpPath }).asCallback(nextMigration);
+            });
+        });
+    }, cb);
+};

--- a/lib/migrator.js
+++ b/lib/migrator.js
@@ -6,6 +6,10 @@ const Hoek = require('hoek');
 const Items = require('items');
 const Tmp = require('tmp');
 
+const internals = {
+    SUPPORTED_EXTENSIONS: ['.co', '.coffee', '.eg', '.iced', '.js', '.litcoffee', '.ls', '.ts'] // from knex
+};
+
 exports.migrate = (knexGroups, defaultKnex, cb) => {
 
     const knexMigrations = new Map();
@@ -64,6 +68,12 @@ exports.migrate = (knexGroups, defaultKnex, cb) => {
                     Items.parallel(migrationsFiles, (file, nextFile) => {
 
                         const name = Path.basename(file);
+
+                        // Don't bother symlinking non-migration files
+
+                        if (internals.SUPPORTED_EXTENSIONS.indexOf(Path.extname(name)) === -1) {
+                            return nextFile();
+                        }
 
                         Fs.symlink(file, Path.join(tmpPath, name), nextFile);
                     }, nextDir);

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -13,7 +13,7 @@ internals.configBase = Joi.object({
 
 exports.plugin = internals.configBase.keys({
     teardownOnStop: Joi.boolean(),
-    migrateOnStart: Joi.boolean(),
+    migrateOnStart: Joi.boolean().truthy('latest').allow('rollback'),
     models: [
         Joi.string(),
         Joi.array().items(internals.model)

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -7,22 +7,22 @@ const internals = {};
 internals.model = Joi.func(); // Really, a class
 
 internals.configBase = Joi.object({
-    knex: [Joi.object(), Joi.func()] // Either a knex config (object) or a knex instance (func)
+    knex: [Joi.object(), Joi.func()], // Either a knex config (object) or a knex instance (func)
+    migrationsDir: Joi.string()
 });
 
 exports.plugin = internals.configBase.keys({
     teardownOnStop: Joi.boolean(),
+    migrateOnStart: Joi.boolean(),
     models: [
         Joi.string(),
         Joi.array().items(internals.model)
-    ],
-    migrationsDirectory: Joi.string()
+    ]
 });
 
 exports.schwifty = Joi.alternatives([
     Joi.array().items(internals.model).single(),
     internals.configBase.keys({
-        models: Joi.array().items(internals.model),
-        migrationsDirectory: Joi.string()
+        models: Joi.array().items(internals.model)
     })
 ]);

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -15,12 +15,14 @@ exports.plugin = internals.configBase.keys({
     models: [
         Joi.string(),
         Joi.array().items(internals.model)
-    ]
+    ],
+    migrationsDirectory: Joi.string()
 });
 
 exports.schwifty = Joi.alternatives([
     Joi.array().items(internals.model).single(),
     internals.configBase.keys({
-        models: Joi.array().items(internals.model)
+        models: Joi.array().items(internals.model),
+        migrationsDirectory: Joi.string()
     })
 ]);

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   "dependencies": {
     "hoek": "4.x.x",
     "items": "2.x.x",
-    "joi": "10.x.x"
+    "joi": "10.x.x",
+    "tmp": "0.0.31"
   },
   "peerDependencies": {
     "hapi": ">=10 <17",

--- a/test/migrations/basic/basic.js
+++ b/test/migrations/basic/basic.js
@@ -1,0 +1,4 @@
+'use strict';
+
+exports.up = () => new Promise((resolve) => resolve());
+exports.down = () => new Promise((resolve) => resolve());

--- a/test/migrations/extras-one/extras-one-1st.js
+++ b/test/migrations/extras-one/extras-one-1st.js
@@ -1,0 +1,4 @@
+'use strict';
+
+exports.up = () => new Promise((resolve) => resolve());
+exports.down = () => new Promise((resolve) => resolve());

--- a/test/migrations/extras-one/extras-one-2nd.js
+++ b/test/migrations/extras-one/extras-one-2nd.js
@@ -1,0 +1,4 @@
+'use strict';
+
+exports.up = () => new Promise((resolve) => resolve());
+exports.down = () => new Promise((resolve) => resolve());

--- a/test/migrations/extras-two/extras-two-1st.js
+++ b/test/migrations/extras-two/extras-two-1st.js
@@ -1,0 +1,4 @@
+'use strict';
+
+exports.up = () => new Promise((resolve) => resolve());
+exports.down = () => new Promise((resolve) => resolve());

--- a/test/migrations/extras-two/extras-two-2nd.js
+++ b/test/migrations/extras-two/extras-two-2nd.js
@@ -1,0 +1,4 @@
+'use strict';
+
+exports.up = () => new Promise((resolve) => resolve());
+exports.down = () => new Promise((resolve) => resolve());

--- a/test/migrations/non-migration/1st-good.js
+++ b/test/migrations/non-migration/1st-good.js
@@ -1,0 +1,4 @@
+'use strict';
+
+exports.up = () => new Promise((resolve) => resolve());
+exports.down = () => new Promise((resolve) => resolve());

--- a/test/migrations/non-migration/2nd-bad.notmigration
+++ b/test/migrations/non-migration/2nd-bad.notmigration
@@ -1,0 +1,4 @@
+'use strict';
+
+exports.up = () => new Promise((resolve) => resolve());
+exports.down = () => new Promise((resolve) => resolve());


### PR DESCRIPTION
Resolves #6, fixes #16.

Adds plugin option `migrateOnStart`, which may be specified once.  When `true`, knex migrations are run during server initialization.  Each plugin may use `srv.schwfity({ migrationsDir: '/what/ever' })` to specify its migrations directory.  Each plugin's migrations are coalesced into a single list of migrations (symlinked into a temp directory), per knex instance.  So plugins may share instances of knex but have different migration directories.  Again, in the end everything is a standard knex migration :)

A side feature– when `migrateOnStart` is `'rollback'`, rather than migrating to latest, the last batch of migrations are rolled-back using their `down` routines.  This is for convenience, and is only as good as its implementation in knex.  Rollbacks should always be done "manually" using this technique– it's not necessarily fit for a rollback during a multi-app deploy, or anything like that.