### PR TITLE
Ping knex connections on server init

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -110,13 +110,51 @@ internals.initialize = (server, next) => {
         });
     });
 
-    if (!collector.migrateOnStart) {
-        return next();
-    }
+    const knexes = internals.getKnexes(collector.knexGroups);
+    const ping = (knex, cb) => {
 
-    const rollback = (collector.migrateOnStart === 'rollback');
+        return knex.queryBuilder().select(knex.raw('1')).asCallback((err) => {
 
-    Migrator.migrate(collector.knexGroups, rootKnex, rollback, next);
+            if (err) {
+                const models = collector.models;
+                const modelNames = Object.keys(models).filter((name) => {
+
+                    return models[name].knex() === knex;
+                });
+
+                // Augment original error message
+
+                const quoted = (x) => `"${x}"`;
+
+                let message = 'Could not connect to database using schwifty knex instance';
+                message += modelNames.length ? ` for models: ${modelNames.map(quoted).join(', ')}.` : '.';
+                err.message = (message + (err.message ? ': ' + err.message : ''));
+
+                return cb(err);
+            };
+
+            return cb();
+        });
+    };
+
+    // Ping each knex connection
+
+    Items.parallel(knexes, ping, (err) => {
+
+        if (err) {
+            return next(err);
+        }
+
+        // Maybe run migrations
+
+        if (!collector.migrateOnStart) {
+            return next();
+        }
+
+        const rollback = (collector.migrateOnStart === 'rollback');
+
+        Migrator.migrate(collector.knexGroups, rootKnex, rollback, next);
+    });
 };
 
 internals.schwifty = function (config) {
@@ -229,13 +267,17 @@ internals.stop = function (server, next) {
         return next();
     }
 
-    let knexes = collector.knexGroups
-        .map((knexGroup) => knexGroup.knex)
-        .filter((maybeKnex) => !!maybeKnex);
-
-    knexes = internals.uniqueObjects(knexes);
+    const knexes = internals.getKnexes(collector.knexGroups);
 
     Items.parallel(knexes, (knex, nxt) => knex.destroy(nxt), next);
+};
+
+internals.getKnexes = (knexGroups) => {
+
+    const knexes = knexGroups.map((knexGroup) => knexGroup.knex)
+                             .filter((maybeKnex) => !!maybeKnex);
+
+    return internals.uniqueObjects(knexes);
 };
 
 // Dedupes an array of objects


### PR DESCRIPTION
For #15.  When the server is initialized, each knex instance's connection should be checked.  This goes nicely with the timing of hapi's checking of catbox/cache connections.  Initialization will fail with a useful error if one of the connections is bad,
```
Could not connect to database using schwifty knex instance for models: "Dog", "Person".
```