### PR TITLE
Perf improvements, preserving model names, support objection v0.7, misc

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -107,7 +107,7 @@ internals.initialize = (server, next) => {
 
             const Model = collector.models[modelName];
 
-            collector.models[modelName] = (knex && !Model.knex()) ? Model.bindKnex(knex) : Model;
+            collector.models[modelName] = (knex && !Model.knex()) ? internals.bindKnex(Model, knex) : Model;
         });
     });
 
@@ -156,6 +156,16 @@ internals.initialize = (server, next) => {
 
         Migrator.migrate(collector.knexGroups, rootKnex, rollback, next);
     });
+};
+
+internals.bindKnex = (Model, knex) => {
+
+    const BoundModel = Model.bindKnex(knex);
+
+    // Preserve model's class name.  If class name ever becomes optional, this will need updating.
+    Object.defineProperty(BoundModel, 'name', { value: Model.name });
+
+    return BoundModel;
 };
 
 internals.schwifty = function (config) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,7 @@
 const Path = require('path');
 const Knex = require('knex');
 const Hoek = require('hoek');
+const Toys = require('toys');
 const Joi = require('joi');
 const Items = require('items');
 const Migrator = require('./migrator');
@@ -215,6 +216,8 @@ internals.schwifty = function (config) {
 
 internals.models = (serverFrom, realmPath) => {
 
+    const getKnexGroup = Toys.reacher(`${realmPath}.plugins.schwifty.knexGroup`);
+
     return function (all) {
 
         const server = serverFrom(this);
@@ -224,7 +227,7 @@ internals.models = (serverFrom, realmPath) => {
             return collector.models;
         }
 
-        const knexGroup = Hoek.reach(this, `${realmPath}.plugins.schwifty.knexGroup`);
+        const knexGroup = getKnexGroup(this);
 
         if (!knexGroup) {
             return {};
@@ -244,10 +247,13 @@ internals.models = (serverFrom, realmPath) => {
 
 internals.knex = (serverFrom, realmPath) => {
 
+    const getFromPlugin = Toys.reacher(`${realmPath}.plugins.schwifty.knexGroup.knex`);
+    const getFromRoot = Toys.reacher('realm.plugins.schwifty.knexGroup.knex');
+
     return function () {
 
-        return Hoek.reach(this, `${realmPath}.plugins.schwifty.knexGroup.knex`) ||
-               Hoek.reach(serverFrom(this).root, 'realm.plugins.schwifty.knexGroup.knex') ||
+        return getFromPlugin(this) ||
+               getFromRoot(serverFrom(this).root) ||
                null;
     };
 };

--- a/package.json
+++ b/package.json
@@ -25,20 +25,21 @@
     "hoek": "4.x.x",
     "items": "2.x.x",
     "joi": "10.x.x",
-    "tmp": "0.0.31"
+    "tmp": "0.0.31",
+    "toys": "1.x.x"
   },
   "peerDependencies": {
     "hapi": ">=10 <17",
-    "knex": ">=0.8.0",
-    "objection": "0.6.x"
+    "knex": ">=0.8",
+    "objection": ">=0.6 <0.8"
   },
   "devDependencies": {
     "code": "4.x.x",
     "coveralls": "2.x.x",
     "hapi": "16.x.x",
     "knex": "0.12.x",
-    "lab": "11.x.x",
-    "objection": "0.6.x",
+    "lab": "13.x.x",
+    "objection": "0.7.x",
     "sqlite3": "3.x.x"
   },
   "author": "William Woodruff <bill@bigroomstudios.com>",

--- a/test/index.js
+++ b/test/index.js
@@ -54,6 +54,11 @@ describe('Schwifty', () => {
         });
     };
 
+    const basicKnexConfig = {
+        client: 'sqlite3',
+        useNullAsDefault: true
+    };
+
     const getServer = (options, cb) => {
 
         const server = new Hapi.Server();
@@ -412,7 +417,7 @@ describe('Schwifty', () => {
 
         it('throws when multiple knex instances passed to same server.', (done) => {
 
-            getServer({ knex: Knex({}) }, (err, server) => {
+            getServer({ knex: Knex(basicKnexConfig) }, (err, server) => {
 
                 expect(err).to.not.exist();
 
@@ -420,7 +425,7 @@ describe('Schwifty', () => {
 
                     server.register({
                         register: Schwifty,
-                        options: { knex: Knex({}) }
+                        options: { knex: Knex(basicKnexConfig) }
                     }, (ignoreErr) => {
 
                         return done(new Error('Should not make it here.'));
@@ -576,7 +581,7 @@ describe('Schwifty', () => {
 
                 expect(err).to.not.exist();
 
-                const knex = Knex({});
+                const knex = Knex(basicKnexConfig);
 
                 const plugin = (srv, opts, next) => {
 
@@ -656,11 +661,11 @@ describe('Schwifty', () => {
 
                 const plugin = (srv, opts, next) => {
 
-                    srv.schwifty({ knex: Knex({}) });
+                    srv.schwifty({ knex: Knex(basicKnexConfig) });
 
                     expect(() => {
 
-                        srv.schwifty({ knex: Knex({}) });
+                        srv.schwifty({ knex: Knex(basicKnexConfig) });
                     }).to.throw('A knex instance/config may be specified only once per server or plugin.');
 
                     next();

--- a/test/index.js
+++ b/test/index.js
@@ -21,6 +21,7 @@ const Schwifty = require('..');
 const lab = exports.lab = Lab.script();
 const expect = Code.expect;
 const describe = lab.describe;
+const before = lab.before;
 const it = lab.it;
 
 describe('Schwifty', () => {
@@ -84,21 +85,14 @@ describe('Schwifty', () => {
         return server.realm.plugins.schwifty;
     };
 
-    it('decorates the Knex instance onto the server.', (done) => {
+    before((done) => {
 
-        getServer(getOptions(), (err, server) => {
+        require('sqlite3'); // Just warm-up sqlite, so that the tests have consistent timing
 
-            expect(err).not.to.exist();
-
-            // Duck type the knex instance
-            expect(server.knex().queryBuilder).to.exist();
-            expect(server.knex().innerJoin).to.exist();
-            expect(server.knex().where).to.exist();
-            done();
-        });
+        done();
     });
 
-    it('connects models to knex instance during onPreStart.', (done) => {
+    it('connects models to knex instance during onPreStart, preserving class names.', (done) => {
 
         const config = getOptions({
             models: [
@@ -111,13 +105,18 @@ describe('Schwifty', () => {
 
             expect(err).to.not.exist();
             expect(server.models().Dog.$$knex).to.not.exist();
+            expect(server.models().Dog.name).to.equal('Dog');
             expect(server.models().Person.$$knex).to.not.exist();
+            expect(server.models().Person.name).to.equal('Person');
 
             server.initialize((err) => {
 
                 expect(err).to.not.exist();
                 expect(server.models().Dog.$$knex).to.exist();
+                expect(server.models().Dog.name).to.equal('Dog');
                 expect(server.models().Person.$$knex).to.exist();
+                expect(server.models().Person.name).to.equal('Person');
+
                 done();
             });
         });


### PR DESCRIPTION
 - Supports objection v0.7.  Closes #29 
 - Perf improvements to `knex()` and `models()` using toys #26 
 - Update lab to v13
 - Preserves model names when knex binding #28  