### PR TITLE
Implement validator interface

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -95,7 +95,7 @@ internals.Validator = class SchwiftyValidator extends Objection.Validator {
 
         ctx.joiSchema = model.constructor.getJoiSchema(options.patch);
 
-        if (model.$beforeValidate !== model.objectionModelClass.prototype.$beforeValidate) {
+        if (model.$beforeValidate !== Objection.Model.prototype.$beforeValidate) {
             ctx.joiSchema = model.$beforeValidate(ctx.joiSchema, json, options);
         }
     }

--- a/lib/model.js
+++ b/lib/model.js
@@ -6,24 +6,35 @@ const internals = {};
 
 module.exports = class SchwiftyModel extends Objection.Model {
 
+    static createValidator() {
+
+        return new internals.Validator();
+    }
+
     // Caches schema, with and without optional keys
-    // Will create _schemaMemo and _optionalSchemaMemo properties
+    // Will create $$joiSchema and $$joiSchemaPatch properties
     static getJoiSchema(patch) {
 
-        if (!this.hasOwnProperty('_schemaMemo')) {
-            this._schemaMemo = this.joiSchema;
+        if (!this.hasOwnProperty('$$joiSchema')) {
+            internals.setNonEnumerableProperty(
+                this,
+                '$$joiSchema',
+                this.joiSchema
+            );
         }
 
-        const schema = this._schemaMemo;
+        const schema = this.$$joiSchema;
 
         if (patch) {
-            if (!this.hasOwnProperty('_patchSchemaMemo')) {
-                this._patchSchemaMemo = internals.patchSchema(schema);
+            if (!this.hasOwnProperty('$$joiSchemaPatch')) {
+                internals.setNonEnumerableProperty(
+                    this,
+                    '$$joiSchemaPatch',
+                    internals.patchSchema(schema)
+                );
             }
 
-            const patchSchema = this._patchSchemaMemo;
-
-            return patchSchema;
+            return this.$$joiSchemaPatch;
         }
 
         return schema;
@@ -34,8 +45,8 @@ module.exports = class SchwiftyModel extends Objection.Model {
     static get jsonAttributes() {
 
         // Once it's set, never recompute from joiSchema
-        if (this.hasOwnProperty('_jsonAttributesMemo')) {
-            return this._jsonAttributesMemo;
+        if (this.hasOwnProperty('$$schwiftyJsonAttributes')) {
+            return this.$$schwiftyJsonAttributes;
         }
 
         const joiSchema = this.getJoiSchema();
@@ -65,41 +76,58 @@ module.exports = class SchwiftyModel extends Objection.Model {
     // Behold.
     static set jsonAttributes(value) {
 
-        this._jsonAttributesMemo = value;
+        internals.setNonEnumerableProperty(
+            this,
+            '$$schwiftyJsonAttributes',
+            value
+        );
+    }
+};
+
+internals.Validator = class SchwiftyValidator extends Objection.Validator {
+
+    beforeValidate(args) {
+
+        const json = args.json;
+        const model = args.model;
+        const options = args.options;
+        const ctx = args.ctx;
+
+        ctx.joiSchema = model.constructor.getJoiSchema(options.patch);
+
+        if (model.$beforeValidate !== model.objectionModelClass.prototype.$beforeValidate) {
+            ctx.joiSchema = model.$beforeValidate(ctx.joiSchema, json, options);
+        }
     }
 
-    static parseJoiValidationError(validation) {
+    validate(args) {
 
-        return validation.error.details;
-    }
+        const json = args.json;
+        const ctx = args.ctx;
 
-    $validate(json, options) { // Note, in objection v0.7.x there is a new Validator interface
-
-        json = json || this.$parseJson(this.$toJson(true));
-        options = options || {};
-
-        let joiSchema = this.constructor.getJoiSchema(options.patch);
-
-        if (!joiSchema || options.skipValidation) {
+        if (!ctx.joiSchema) {
             return json;
         }
 
-        // Allow modification of schema, setting of options, etc.
-        joiSchema = this.$beforeValidate(joiSchema, json, options);
-
-        const validation = joiSchema.validate(json);
+        const validation = ctx.joiSchema.validate(json);
 
         if (validation.error) {
-            const errors = this.constructor.parseJoiValidationError(validation);
-            throw new Objection.ValidationError(errors);
+            const info = internals.parseJoiValidationError(validation);
+            throw new Objection.ValidationError(info);
         }
 
-        json = validation.value;
-
-        this.$afterValidate(json, options);
-
-        return json;
+        return validation.value;
     }
+};
+
+internals.setNonEnumerableProperty = (obj, prop, value) => {
+
+    Object.defineProperty(obj, prop, {
+        enumerable: false,
+        writable: true,
+        configurable: true,
+        value
+    });
 };
 
 internals.patchSchema = (schema) => {
@@ -117,4 +145,23 @@ internals.patchSchema = (schema) => {
     }
 
     return schema.options({ noDefaults: true });
+};
+
+internals.parseJoiValidationError = (validation) => {
+
+    const errors = validation.error.details;
+    const validationInfo = {};
+
+    for (let i = 0; i < errors.length; ++i) {
+        const error = errors[i];
+
+        validationInfo[error.path] = validationInfo[error.path] || [];
+        validationInfo[error.path].push({
+            message: error.message,
+            keyword: error.type,
+            params: error.context
+        });
+    }
+
+    return validationInfo;
 };

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "peerDependencies": {
     "hapi": ">=10 <17",
     "knex": ">=0.8",
-    "objection": ">=0.6 <0.9"
+    "objection": ">=0.7 <0.9"
   },
   "devDependencies": {
     "code": "4.x.x",

--- a/test/index.js
+++ b/test/index.js
@@ -1881,6 +1881,41 @@ describe('Schwifty', () => {
                 done();
             });
 
+            it('can modify validation schema using model.$beforeValidate().', (done) => {
+
+                let seenSchema;
+                let seenJson;
+                let seenOptions;
+
+                const Model = class extends Schwifty.Model {
+                    static get joiSchema() {
+
+                        return Joi.object();
+                    }
+
+                    $beforeValidate(schema, json, options) {
+
+                        seenSchema = schema;
+                        seenJson = json;
+                        seenOptions = options;
+
+                        return schema.keys({
+                            persnicketyField: Joi.string().max(1)
+                        });
+                    }
+                };
+
+                const instance = new Model();
+                const persnickety = { persnicketyField: 'xxxxx' }; // Length of 5, bigger than max
+
+                expect(() => instance.$validate(persnickety)).to.throw(Objection.ValidationError);
+                expect(seenSchema).to.shallow.equal(Model.getJoiSchema());
+                expect(seenJson).to.equal(persnickety);
+                expect(seenOptions).to.equal({});
+
+                done();
+            });
+
             it('skips validation if model is missing joiSchema.', (done) => {
 
                 const anythingGoes = new Schwifty.Model();

--- a/test/index.js
+++ b/test/index.js
@@ -1825,6 +1825,62 @@ describe('Schwifty', () => {
                 done();
             });
 
+            it('throws Objection.ValidationError with multiple errors per key.', (done) => {
+
+                const Model = class extends Schwifty.Model {
+                    static get joiSchema() {
+
+                        return Joi.object({
+                            persnicketyField: Joi.string().max(1).min(10)
+                        })
+                        .options({
+                            abortEarly: false
+                        });
+                    }
+                };
+
+                const instance = new Model();
+                const persnickety = { persnicketyField: 'xxxxx' }; // Length of 5, bigger than max and less than min
+
+                let error;
+
+                try {
+                    instance.$validate(persnickety);
+                }
+                catch (e) {
+                    error = e;
+                }
+
+                expect(error).to.be.an.instanceof(Objection.ValidationError);
+
+                expect(error.data).to.equal({
+                    persnicketyField: [
+                        {
+                            message: '"persnicketyField" length must be less than or equal to 1 characters long',
+                            keyword: 'string.max',
+                            params: {
+                                limit: 1,
+                                value: 'xxxxx',
+                                encoding: undefined,
+                                key: 'persnicketyField'
+                            }
+                        },
+                        {
+                            message: '"persnicketyField" length must be at least 10 characters long',
+                            keyword: 'string.min',
+                            params: {
+                                limit: 10,
+                                value: 'xxxxx',
+                                encoding: undefined,
+                                key: 'persnicketyField'
+                            }
+                        }
+                    ]
+                });
+
+                done();
+            });
+
             it('skips validation if model is missing joiSchema.', (done) => {
 
                 const anythingGoes = new Schwifty.Model();
@@ -2040,7 +2096,7 @@ describe('Schwifty', () => {
         describe('static setter jsonAttributes', () => {
 
             // A quick dip into unit (vs behavioral) testing!
-            it('sets _jsonAttributesMemo', (done) => {
+            it('sets $$schwiftyJsonAttributes', (done) => {
 
                 const Model = class extends Schwifty.Model {
                     static get joiSchema() {
@@ -2056,10 +2112,10 @@ describe('Schwifty', () => {
 
                 const jsonAttrs = Model.jsonAttributes;
                 expect(jsonAttrs).to.equal(['arr', 'obj']);
-                expect(jsonAttrs).to.shallow.equal(Model._jsonAttributesMemo);
+                expect(jsonAttrs).to.shallow.equal(Model.$$schwiftyJsonAttributes);
 
                 const emptyJsonAttrs = Model.jsonAttributes = [];
-                expect(emptyJsonAttrs).to.shallow.equal(Model._jsonAttributesMemo);
+                expect(emptyJsonAttrs).to.shallow.equal(Model.$$schwiftyJsonAttributes);
 
                 done();
             });


### PR DESCRIPTION
Resolves #23.

Implements the [validator interface](http://vincit.github.io/objection.js/#validator) from objection v0.7/0.8.  This a breaking change, so it will be part of schwifty v2.