### PR TITLE
Respect server.path(), update deps, let objection preserve model class names

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -67,7 +67,7 @@ exports.register = (server, options, next) => {
         rootCollector.migrateOnStart = options.migrateOnStart;
     }
 
-    const config = internals.registrationConfig(options);
+    const config = internals.registrationConfig(options, server.root);
     server.root.schwifty(config);
 
     return next();
@@ -79,7 +79,7 @@ exports.register.attributes = {
 };
 
 // Massage registration config for use with rejoice
-internals.registrationConfig = (options) => {
+internals.registrationConfig = (options, rootServer) => {
 
     const config = Hoek.shallow(options);
 
@@ -93,7 +93,8 @@ internals.registrationConfig = (options) => {
             config.models = require(config.models);
         }
         else {
-            config.models = require(Path.resolve(process.cwd(), config.models));
+            const relativeTo = rootServer.realm.settings.files.relativeTo || '';
+            config.models = require(Path.resolve(relativeTo, config.models));       // Path.resolve() defaults to cwd as base
         }
     }
 
@@ -115,7 +116,7 @@ internals.initialize = (server, next) => {
 
             const Model = collector.models[modelName];
 
-            collector.models[modelName] = (knex && !Model.knex()) ? internals.bindKnex(Model, knex) : Model;
+            collector.models[modelName] = (knex && !Model.knex()) ? Model.bindKnex(knex) : Model;
         });
     });
 
@@ -166,16 +167,6 @@ internals.initialize = (server, next) => {
     });
 };
 
-internals.bindKnex = (Model, knex) => {
-
-    const BoundModel = Model.bindKnex(knex);
-
-    // Preserve model's class name.  If class name ever becomes optional, this will need updating.
-    Object.defineProperty(BoundModel, 'name', { value: Model.name });
-
-    return BoundModel;
-};
-
 internals.schwifty = function (config) {
 
     config = Joi.attempt(config, Schema.schwifty);
@@ -197,7 +188,7 @@ internals.schwifty = function (config) {
     if (!state.knexGroup) {
         state.knexGroup = {
             models: [],
-            migrationsDir: null,
+            migrationsDir: null,    // If present, will be resolved to an absolute path
             knex: null
         };
 
@@ -208,7 +199,8 @@ internals.schwifty = function (config) {
 
     if (typeof config.migrationsDir !== 'undefined') {
         Hoek.assert(state.knexGroup.migrationsDir === null, 'Schwifty\'s migrationsDir plugin option can only be specified once per plugin.');
-        state.knexGroup.migrationsDir = config.migrationsDir;
+        const relativeTo = this.realm.settings.files.relativeTo || '';
+        state.knexGroup.migrationsDir = Path.resolve(relativeTo, config.migrationsDir);
     }
 
     // Collect models ensuring no dupes
@@ -232,13 +224,13 @@ internals.schwifty = function (config) {
     }
 };
 
-internals.models = (serverFrom, realmPath) => {
+internals.models = (getServer, realmPath) => {
 
     const getKnexGroup = Toys.reacher(`${realmPath}.plugins.schwifty.knexGroup`);
 
     return function (all) {
 
-        const server = serverFrom(this);
+        const server = getServer(this);
         const collector = internals.state(server.root).collector;
 
         if (all) {
@@ -263,7 +255,7 @@ internals.models = (serverFrom, realmPath) => {
     };
 };
 
-internals.knex = (serverFrom, realmPath) => {
+internals.knex = (getServer, realmPath) => {
 
     const getFromPlugin = Toys.reacher(`${realmPath}.plugins.schwifty.knexGroup.knex`);
     const getFromRoot = Toys.reacher('realm.plugins.schwifty.knexGroup.knex');
@@ -271,7 +263,7 @@ internals.knex = (serverFrom, realmPath) => {
     return function () {
 
         return getFromPlugin(this) ||
-               getFromRoot(serverFrom(this).root) ||
+               getFromRoot(getServer(this).root) ||
                null;
     };
 };

--- a/lib/migrator.js
+++ b/lib/migrator.js
@@ -18,7 +18,7 @@ exports.migrate = (knexGroups, defaultKnex, rollback, cb) => {
 
     for (let i = 0; i < knexGroups.length; ++i) {
         const knexGroup = knexGroups[i];
-        const migrationsDir = knexGroup.migrationsDir;
+        const migrationsDir = knexGroup.migrationsDir;  // Already normalized to abs path
 
         if (!migrationsDir) {
             continue;
@@ -34,12 +34,7 @@ exports.migrate = (knexGroups, defaultKnex, rollback, cb) => {
 
         const migrationsDirs = knexMigrations.get(knex);
 
-        // Absolutize and normalize
-        const absMigrationsDir = Path.isAbsolute(migrationsDir) ?
-                                    Path.normalize(migrationsDir) :
-                                    Path.join(process.cwd(), migrationsDir);
-
-        migrationsDirs[absMigrationsDir] = true;
+        migrationsDirs[migrationsDir] = true;
     }
 
     // For each knex instance

--- a/package.json
+++ b/package.json
@@ -25,13 +25,13 @@
     "hoek": "4.x.x",
     "items": "2.x.x",
     "joi": "10.x.x",
-    "tmp": "0.0.31",
+    "tmp": "0.0.32",
     "toys": "1.x.x"
   },
   "peerDependencies": {
     "hapi": ">=10 <17",
     "knex": ">=0.8",
-    "objection": ">=0.7 <0.9"
+    "objection": ">=0.7.6 <0.9"
   },
   "devDependencies": {
     "code": "4.x.x",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "hoek": "4.x.x",
     "items": "2.x.x",
     "joi": "10.x.x",
-    "tmp": "0.0.32",
+    "tmp": "0.0.31",
     "toys": "1.x.x"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "peerDependencies": {
     "hapi": ">=10 <17",
     "knex": ">=0.8",
-    "objection": ">=0.7.6 <0.9"
+    "objection": ">=0.7 <0.9"
   },
   "devDependencies": {
     "code": "4.x.x",

--- a/test/index.js
+++ b/test/index.js
@@ -331,6 +331,28 @@ describe('Schwifty', () => {
             });
         });
 
+        it('takes `models` option respecting server.path().', (done) => {
+
+            const server = new Hapi.Server();
+            server.connection();
+            server.path(__dirname);
+
+            server.register({
+                register: Schwifty,
+                options: getOptions({ models: modelsFile })
+            }, (err) => {
+
+                expect(err).to.not.exist();
+
+                const models = server.models();
+
+                expect(models.Dog).to.exist();
+                expect(models.Person).to.exist();
+
+                done();
+            });
+        });
+
         it('takes `models` option as an array of objects.', (done) => {
 
             const options = getOptions({
@@ -1280,6 +1302,38 @@ describe('Schwifty', () => {
                         expect(version).to.equal('basic.js');
 
                         done();
+                    });
+                });
+            });
+        });
+
+        it('respects server.path() when setting `migrationsDir`.', (done) => {
+
+            getServer(getOptions({
+                migrateOnStart: true
+            }), (err, server) => {
+
+                expect(err).to.not.exist();
+
+                server.path(`${__dirname}/migrations`);
+                server.schwifty({ migrationsDir: 'basic' });
+
+                server.knex().migrate.currentVersion().asCallback((err, versionPre) => {
+
+                    expect(err).to.not.exist();
+                    expect(versionPre).to.equal('none');
+
+                    server.initialize((err) => {
+
+                        expect(err).to.not.exist();
+
+                        server.knex().migrate.currentVersion().asCallback((err, versionPost) => {
+
+                            expect(err).to.not.exist();
+                            expect(versionPost).to.equal('basic.js');
+
+                            done();
+                        });
                     });
                 });
             });

--- a/test/index.js
+++ b/test/index.js
@@ -92,7 +92,7 @@ describe('Schwifty', () => {
         done();
     });
 
-    it('connects models to knex instance during onPreStart, preserving class names.', (done) => {
+    it('connects models to knex instance during onPreStart.', (done) => {
 
         const config = getOptions({
             models: [
@@ -105,17 +105,13 @@ describe('Schwifty', () => {
 
             expect(err).to.not.exist();
             expect(server.models().Dog.$$knex).to.not.exist();
-            expect(server.models().Dog.name).to.equal('Dog');
             expect(server.models().Person.$$knex).to.not.exist();
-            expect(server.models().Person.name).to.equal('Person');
 
             server.initialize((err) => {
 
                 expect(err).to.not.exist();
                 expect(server.models().Dog.$$knex).to.exist();
-                expect(server.models().Dog.name).to.equal('Dog');
                 expect(server.models().Person.$$knex).to.exist();
-                expect(server.models().Person.name).to.equal('Person');
 
                 done();
             });


### PR DESCRIPTION
- Updates dependencies (`tmp`)
- Closes #24, now respecting `server.path()` when set.
- Closes #36, now leaning on objection to preserve model class names when knex is bound to a model.

Note that this currently is a PR into #35, simply to provide a meaningful diff (since this PR branches from when #35 left off).  Once #35 is merged, we'll change the base of this PR to master.