### PR TITLE
Attribute relation check

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const Os = require('os');
 const Path = require('path');
 const Knex = require('knex');
 const Hoek = require('hoek');
@@ -107,6 +108,21 @@ internals.initialize = (server, next) => {
     const collector = rootState.collector;
     const rootKnex = Hoek.reach(rootState, 'knexGroup.knex') || null;
 
+    // Check for invalid model configuration
+    let modelErrors = Object.keys(collector.models).map((modelName) => {
+
+        const Model = collector.models[modelName];
+
+        return internals.modelErrors(Model, modelName);
+    });
+
+    modelErrors = Hoek.flatten(modelErrors);
+
+    if (modelErrors.length) {
+        const errorMessages = modelErrors.map((e) => e.message).join(Os.EOL);
+        return next(new Error(errorMessages));
+    }
+
     collector.knexGroups.forEach((knexGroup) => {
 
         const models = knexGroup.models;
@@ -115,22 +131,6 @@ internals.initialize = (server, next) => {
         models.forEach((modelName) => {
 
             const Model = collector.models[modelName];
-
-            const relations = new Set(Object.keys(Model.getRelations()));
-            const schema = new Set(Object.keys(Model.getJoiSchema().describe().children));
-
-            //compute the intersection between the two sets.  Any collision is an error
-            const intersection = [...relations].filter((x) => schema.has(x));
-
-            if (intersection.length > 0){
-
-                if (intersection.length > 1) {
-                    const collisionError = new Error('Model ' + modelName + ' attributes ' + intersection.toString() + ' conflict with relations of the same names.  Names must be unique.');
-                    return next(collisionError);
-                }
-                const collisionError = new Error('Model ' + modelName + ' attribute ' + intersection.toString() + ' conflicts with relation of the same name.  Names must be unique.');
-                return next(collisionError);
-            }
 
             collector.models[modelName] = (knex && !Model.knex()) ? Model.bindKnex(knex) : Model;
         });
@@ -181,6 +181,28 @@ internals.initialize = (server, next) => {
 
         Migrator.migrate(collector.knexGroups, rootKnex, rollback, next);
     });
+};
+
+internals.modelErrors = (Model, modelName) => {
+
+    const relations = new Set(Object.keys(Model.getRelations()));
+    const schema = new Set(Object.keys(Model.getJoiSchema().describe().children));
+
+    // Compute the intersection between the two sets.  Any collision is an error.
+    const intersection = Array.from(relations).filter((x) => schema.has(x));
+
+    if (intersection.length > 0){
+
+        if (intersection.length > 1) {
+            const collisionError = new Error('Model ' + modelName + ' attributes ' + intersection.toString() + ' conflict with relations of the same names.  Names must be unique.');
+            return [collisionError];
+        }
+
+        const collisionError = new Error('Model ' + modelName + ' attribute ' + intersection.toString() + ' conflicts with relation of the same name.  Names must be unique.');
+        return [collisionError];
+    }
+
+    return [];
 };
 
 internals.schwifty = function (config) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -116,6 +116,22 @@ internals.initialize = (server, next) => {
 
             const Model = collector.models[modelName];
 
+            const relations = new Set(Object.keys(Model.getRelations()));
+            const schema = new Set(Object.keys(Model.getJoiSchema().describe().children));
+
+            //compute the intersection between the two sets.  Any collision is an error
+            const intersection = [...relations].filter((x) => schema.has(x));
+
+            if (intersection.length > 0){
+
+                if (intersection.length > 1) {
+                    const collisionError = new Error('Model ' + modelName + ' attributes ' + intersection.toString() + ' conflict with relations of the same names.  Names must be unique.');
+                    return next(collisionError);
+                }
+                const collisionError = new Error('Model ' + modelName + ' attribute ' + intersection.toString() + ' conflicts with relation of the same name.  Names must be unique.');
+                return next(collisionError);
+            }
+
             collector.models[modelName] = (knex && !Model.knex()) ? Model.bindKnex(knex) : Model;
         });
     });

--- a/lib/index.js
+++ b/lib/index.js
@@ -194,7 +194,7 @@ internals.modelErrors = (Model, modelName) => {
     if (intersection.length > 0){
 
         if (intersection.length > 1) {
-            const collisionError = new Error('Model ' + modelName + ' attributes ' + intersection.toString() + ' conflict with relations of the same names.  Names must be unique.');
+            const collisionError = new Error('Model ' + modelName + ' attributes ' + intersection.join(', ') + ' conflict with relations of the same names.  Names must be unique.');
             return [collisionError];
         }
 

--- a/test/index.js
+++ b/test/index.js
@@ -334,7 +334,65 @@ describe('Schwifty', () => {
             server.initialize((err) => {
 
                 expect(err).to.exist();
-                expect(err.message).to.startWith('Model');
+                expect(err.message).to.startWith('Model Collision attribute ');
+
+                done();
+            });
+        });
+    });
+
+    it('throws a pluralized error if there is a naming collision between multiple attributes and relations.', (done) => {
+
+        const Collision = class Collision extends Schwifty.Model {
+            static get tableName() {
+
+                return 'Collision';
+            }
+
+            static get joiSchema() {
+
+                return Joi.object({
+                    id: Joi.number().integer(),
+                    badName: Joi.string(),
+                    anotherBadName: Joi.string()
+                });
+            }
+
+            static get relationMappings() {
+
+                return {
+                    badName: {
+                        relation: Schwifty.Model.BelongsToOneRelation,
+                        modelClass: require('./models/person'),
+                        join: {
+                            from: 'Collision.badName',
+                            to: 'Person.firstName'
+                        }
+                    },
+                    anotherBadName: {
+                        relation: Schwifty.Model.BelongsToOneRelation,
+                        modelClass: require('./models/person'),
+                        join: {
+                            from: 'Collision.anotherBadName',
+                            to: 'Person.firstName'
+                        }
+                    }
+                };
+            }
+        };
+        getServer(getOptions({
+            models: [
+                TestModels.Person,
+                Collision
+            ]
+        }), (err, server) => {
+
+            expect(err).not.to.exist();
+
+            server.initialize((err) => {
+
+                expect(err).to.exist();
+                expect(err.message).to.startWith('Model Collision attributes');
 
                 done();
             });

--- a/test/index.js
+++ b/test/index.js
@@ -292,6 +292,55 @@ describe('Schwifty', () => {
         });
     });
 
+    it('throws an error if there is a naming collision between attributes and relations.', (done) => {
+
+        const Collision = class Collision extends Schwifty.Model {
+            static get tableName() {
+
+                return 'Collision';
+            }
+
+            static get joiSchema() {
+
+                return Joi.object({
+                    id: Joi.number().integer(),
+                    badName: Joi.string()
+                });
+            }
+
+            static get relationMappings() {
+
+                return {
+                    badName: {
+                        relation: Schwifty.Model.BelongsToOneRelation,
+                        modelClass: require('./models/person'),
+                        join: {
+                            from: 'Collision.badName',
+                            to: 'Person.firstName'
+                        }
+                    }
+                };
+            }
+        };
+        getServer(getOptions({
+            models: [
+                TestModels.Person,
+                Collision
+            ]
+        }), (err, server) => {
+
+            expect(err).not.to.exist();
+
+            server.initialize((err) => {
+
+                expect(err).to.exist();
+                expect(err.message).to.startWith('Model');
+
+                done();
+            });
+        });
+    });
+
     describe('plugin registration', () => {
 
         it('takes `models` option as a relative path.', (done) => {


### PR DESCRIPTION
Schwifty will now error on server start if you have a collision between model attributes and relations.  Objection doesn't handle this well, and it's hard to do there, so handle it here instead.