### PR TITLE
Hapi17 decorations tests

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -24,7 +24,7 @@ exports.assertCompatible = (A, B, msg) => {
 
 exports.plugin = {
     pkg: Package,
-    mutliple: true,
+    multiple: true,
     register: function (server, options) {
 
         Joi.assert(options, Schema.plugin, 'Bad plugin options passed to schwifty.');
@@ -43,6 +43,7 @@ exports.plugin = {
 
             // Here's the ORM!
 
+            // We simplify the external interface to schwifty to just the configuration, so the user doesn't have to worry about servers and realms
             server.decorate('server', 'schwifty', function (config) {
 
                 internals.schwifty(this, this.realm, config);
@@ -298,8 +299,7 @@ internals.stop = async function (server) {
     }
 
     const knexes = internals.getKnexes(collector.knexGroups);
-    // TODO Should this be just .destroy or .destroy()???
-    const knexPromises = knexes.map((knex) => knex.destroy);
+    const knexPromises = knexes.map((knex) => knex.destroy());
 
     await Promise.all(knexPromises);
 

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -21,6 +21,8 @@ exports.plugin = internals.configBase.keys({
 });
 
 exports.schwifty = Joi.alternatives([
+    // .single() converts a single model definition to an array containing that model
+    // allowing a single model to fit with the array-to-config coercion in index::internals.schwifty
     Joi.array().items(internals.model).single(),
     internals.configBase.keys({
         models: Joi.array().items(internals.model)

--- a/test/index.js
+++ b/test/index.js
@@ -564,7 +564,7 @@ describe('Schwifty', () => {
                     srv.route({
                         path: '/plugin',
                         method: 'get',
-                        handler: (request, h) => {
+                        handler: (request) => {
 
                             expect(request.knex()).to.shallow.equal(knex);
                             return { ok: true };
@@ -600,7 +600,7 @@ describe('Schwifty', () => {
                     srv.route({
                         path: '/plugin',
                         method: 'get',
-                        handler: (request, h) => {
+                        handler: (request) => {
 
                             expect(request.knex()).to.shallow.equal(knex2);
                             return { ok: true };
@@ -631,7 +631,7 @@ describe('Schwifty', () => {
                     srv.route({
                         path: '/plugin',
                         method: 'get',
-                        handler: (request, h) => {
+                        handler: (request) => {
 
                             expect(request.knex()).to.equal(null);
                             return { ok: true };
@@ -1183,7 +1183,7 @@ describe('Schwifty', () => {
         });
     });
 
-    describe('request.models() and server.models() decorations', () => {
+    describe.only('request.models() and server.models() decorations', () => {
 
         it('return empty object before server initialization.', async () => {
 
@@ -1192,7 +1192,7 @@ describe('Schwifty', () => {
             server.route({
                 path: '/',
                 method: 'get',
-                handler: (request, h) => {
+                handler: (request) => {
 
                     expect(request.models()).to.equal({});
                     expect(request.models(true)).to.equal({});
@@ -1215,7 +1215,7 @@ describe('Schwifty', () => {
             server.route({
                 path: '/root',
                 method: 'get',
-                handler: (request, h) => {
+                handler: (request) => {
 
                     expect(request.models()).to.equal({});
                     expect(request.models(true)).to.equal({});
@@ -1237,7 +1237,7 @@ describe('Schwifty', () => {
                     srv.route({
                         path: '/plugin',
                         method: 'get',
-                        handler: (request, h) => {
+                        handler: (request) => {
 
                             const _knexGroupId = state(srv.realm);
                             expect(_knexGroupId).to.not.exist();
@@ -1273,7 +1273,7 @@ describe('Schwifty', () => {
             server.route({
                 path: '/root',
                 method: 'get',
-                handler: (request, h) => {
+                handler: (request) => {
 
                     const models = request.models();
                     expect(models).to.have.length(2);
@@ -1283,7 +1283,7 @@ describe('Schwifty', () => {
                 }
             });
 
-            server.ext('onPreStart', (_) => {
+            server.ext('onPreStart', () => {
 
                 const models = server.models();
                 expect(models).to.have.length(2);
@@ -1300,7 +1300,7 @@ describe('Schwifty', () => {
                     srv.route({
                         path: '/plugin',
                         method: 'get',
-                        handler: (request, h) => {
+                        handler: (request) => {
 
                             const models = request.models();
                             expect(models).to.have.length(1);
@@ -1308,7 +1308,7 @@ describe('Schwifty', () => {
                             return { ok: 'plugin' };
                         }
                     });
-                    srv.ext('onPreStart', (_) => {
+                    srv.ext('onPreStart', () => {
 
                         const models = srv.models();
                         expect(models).to.have.length(1);
@@ -1339,7 +1339,7 @@ describe('Schwifty', () => {
                     srv.route({
                         path: '/',
                         method: 'get',
-                        handler: (request, h) => {
+                        handler: (request) => {
 
                             const models = request.models();
                             expect(models).to.be.an.object();
@@ -1347,7 +1347,7 @@ describe('Schwifty', () => {
                             return { ok: true };
                         }
                     });
-                    srv.ext('onPreStart', (_) => {
+                    srv.ext('onPreStart', () => {
 
                         const models = srv.models();
                         expect(models).to.be.an.object();
@@ -1378,7 +1378,7 @@ describe('Schwifty', () => {
             server.route({
                 path: '/root',
                 method: 'get',
-                handler: (request, h) => {
+                handler: (request) => {
 
                     const models = request.models(true);
                     expect(models).to.have.length(3);
@@ -1388,7 +1388,7 @@ describe('Schwifty', () => {
                     return { ok: 'root' };
                 }
             });
-            server.ext('onPreStart', (_) => {
+            server.ext('onPreStart', () => {
 
                 const models = server.models(true);
                 expect(models).to.have.length(3);
@@ -1406,7 +1406,7 @@ describe('Schwifty', () => {
                     srv.route({
                         path: '/plugin',
                         method: 'get',
-                        handler: (request, h) => {
+                        handler: (request) => {
 
                             const models = request.models(true);
                             expect(models).to.have.length(3);
@@ -1416,7 +1416,7 @@ describe('Schwifty', () => {
                             return { ok: 'plugin' };
                         }
                     });
-                    srv.ext('onPreStart', (_) => {
+                    srv.ext('onPreStart', () => {
 
                         const models = srv.models(true);
                         expect(models).to.have.length(3);


### PR DESCRIPTION
A pile of rewritten tests

Items of particular consideration, to help sift through :)
- `'return empty object before server initialization.'` test;  should this be patched to include adding models? Currently, no models added, so result is same even if initialization
- Is modification to the state function ok? For example, modified version used in `'return empty object if no models have been added.'` (basically, switching from inspecting server ref to realm)?
