### PR TITLE
Update to Objection v.1, address failing tests

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -104,6 +104,7 @@ internals.Validator = class SchwiftyValidator extends Objection.Validator {
     validate(args) {
 
         const json = args.json;
+        const model = args.model;
         const ctx = args.ctx;
 
         if (!ctx.joiSchema) {
@@ -113,11 +114,7 @@ internals.Validator = class SchwiftyValidator extends Objection.Validator {
         const validation = ctx.joiSchema.validate(json);
 
         if (validation.error) {
-            const info = internals.parseJoiValidationError(validation);
-
-            // constructor must be passed object of schema
-            // { type, message, data = {}, statusCode = 400 }
-            throw new Objection.ValidationError(info);
+            throw internals.parseJoiValidationError(validation, model.constructor);
         }
 
         return validation.value;
@@ -153,7 +150,7 @@ internals.patchSchema = (schema) => {
 
 // Converts a Joi error object to the format the Object.ValidationError constructor expects as input
 // https://github.com/Vincit/objection.js/blob/aa3f1a0bb830211e478aa6a664561155c98850f4/lib/model/ValidationError.js#L10
-internals.parseJoiValidationError = (validation) => {
+internals.parseJoiValidationError = (validation, modelClass) => {
 
     const errors = validation.error.details;
     const validationInfo = {
@@ -168,11 +165,14 @@ internals.parseJoiValidationError = (validation) => {
 
         validationInfo.data[error.path] = validationInfo.data[error.path] || [];
         validationInfo.data[error.path].push({
+            // Format matches data property documented here: http://vincit.github.io/objection.js/#validationerror
             message: error.message,
-            joiType: error.type,
-            data: error.context
+            keyword: error.type,
+            params: error.context
         });
     }
 
-    return validationInfo;
+    // inherited standard method on Objection models (http://vincit.github.io/objection.js/#createvalidationerror)
+    // just handles creating a standard ValidationError
+    return modelClass.createValidationError(validationInfo);
 };

--- a/lib/model.js
+++ b/lib/model.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const Objection = require('objection');
+const { ModelValidation } = Objection.ValidationError.Type;
 
 const internals = {};
 
@@ -110,7 +111,6 @@ internals.Validator = class SchwiftyValidator extends Objection.Validator {
         }
 
         const validation = ctx.joiSchema.validate(json);
-        //console.log('JUST VALIDATED', validation);
 
         if (validation.error) {
             const info = internals.parseJoiValidationError(validation);
@@ -156,26 +156,20 @@ internals.patchSchema = (schema) => {
 internals.parseJoiValidationError = (validation) => {
 
     const errors = validation.error.details;
-    const validationInfo = {};
-
-    if (errors.length === 1) {
-        const error = errors[0];
-        validationInfo.message = error.message;
-        validationInfo.data = error.context;
-        validationInfo.type = error.type;
-        return validationInfo;
-    }
+    const validationInfo = {
+        data: {},
+        type: ModelValidation
+    };
 
     // We don't set a message, as Objection will build an error message from the message properties of
     // values within the data property of the ValidationError constructor's input
-    validationInfo.data = {};
     for (let i = 0; i < errors.length; ++i) {
         const error = errors[i];
 
         validationInfo.data[error.path] = validationInfo.data[error.path] || [];
         validationInfo.data[error.path].push({
             message: error.message,
-            type: error.type,
+            joiType: error.type,
             data: error.context
         });
     }

--- a/lib/model.js
+++ b/lib/model.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const Objection = require('objection');
-const { ModelValidation } = Objection.ValidationError.Type;
 
 const internals = {};
 
@@ -150,12 +149,12 @@ internals.patchSchema = (schema) => {
 
 // Converts a Joi error object to the format the Object.ValidationError constructor expects as input
 // https://github.com/Vincit/objection.js/blob/aa3f1a0bb830211e478aa6a664561155c98850f4/lib/model/ValidationError.js#L10
-internals.parseJoiValidationError = (validation, modelClass) => {
+internals.parseJoiValidationError = (validation, Model) => {
 
     const errors = validation.error.details;
     const validationInfo = {
         data: {},
-        type: ModelValidation
+        type: 'ModelValidation'
     };
 
     // We don't set a message, as Objection will build an error message from the message properties of
@@ -174,5 +173,5 @@ internals.parseJoiValidationError = (validation, modelClass) => {
 
     // inherited standard method on Objection models (http://vincit.github.io/objection.js/#createvalidationerror)
     // just handles creating a standard ValidationError
-    return modelClass.createValidationError(validationInfo);
+    return Model.createValidationError(validationInfo);
 };

--- a/lib/model.js
+++ b/lib/model.js
@@ -110,9 +110,13 @@ internals.Validator = class SchwiftyValidator extends Objection.Validator {
         }
 
         const validation = ctx.joiSchema.validate(json);
+        //console.log('JUST VALIDATED', validation);
 
         if (validation.error) {
             const info = internals.parseJoiValidationError(validation);
+
+            // constructor must be passed object of schema
+            // { type, message, data = {}, statusCode = 400 }
             throw new Objection.ValidationError(info);
         }
 
@@ -147,19 +151,32 @@ internals.patchSchema = (schema) => {
     return schema.options({ noDefaults: true });
 };
 
+// Converts a Joi error object to the format the Object.ValidationError constructor expects as input
+// https://github.com/Vincit/objection.js/blob/aa3f1a0bb830211e478aa6a664561155c98850f4/lib/model/ValidationError.js#L10
 internals.parseJoiValidationError = (validation) => {
 
     const errors = validation.error.details;
     const validationInfo = {};
 
+    if (errors.length === 1) {
+        const error = errors[0];
+        validationInfo.message = error.message;
+        validationInfo.data = error.context;
+        validationInfo.type = error.type;
+        return validationInfo;
+    }
+
+    // We don't set a message, as Objection will build an error message from the message properties of
+    // values within the data property of the ValidationError constructor's input
+    validationInfo.data = {};
     for (let i = 0; i < errors.length; ++i) {
         const error = errors[i];
 
-        validationInfo[error.path] = validationInfo[error.path] || [];
-        validationInfo[error.path].push({
+        validationInfo.data[error.path] = validationInfo.data[error.path] || [];
+        validationInfo.data[error.path].push({
             message: error.message,
-            keyword: error.type,
-            params: error.context
+            type: error.type,
+            data: error.context
         });
     }
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "peerDependencies": {
     "hapi": ">=17 <18",
     "knex": ">=0.8",
-    "objection": ">=0.7 <0.10"
+    "objection": ">=1 <2"
   },
   "devDependencies": {
     "code": "5.x.x",
@@ -38,7 +38,7 @@
     "hapi": "17.x.x",
     "knex": "0.14.x",
     "lab": "15.x.x",
-    "objection": "0.9.x",
+    "objection": "1.x.x",
     "sqlite3": "3.x.x"
   },
   "author": "William Woodruff <bill@bigroomstudios.com>",

--- a/test/index.js
+++ b/test/index.js
@@ -1313,7 +1313,7 @@ describe('Schwifty', () => {
                     chompy.$validate({
                         lastName: 'Chomperson'
                     });
-                }).to.throw(Objection.ValidationError, /\\\"firstName\\\" is required/);
+                }).to.throw(Objection.ValidationError, /"firstName" is required/);
             });
 
             it('throws Objection.ValidationError if bad types are passed.', () => {
@@ -1326,7 +1326,7 @@ describe('Schwifty', () => {
                         firstName: 'Chompy',
                         lastName: 1234
                     });
-                }).to.throw(Objection.ValidationError, /\\\"lastName\\\" must be a string/);
+                }).to.throw(Objection.ValidationError, /"lastName" must be a string/);
             });
 
             it('throws Objection.ValidationError with multiple errors per key.', () => {
@@ -1360,8 +1360,8 @@ describe('Schwifty', () => {
                     persnicketyField: [
                         {
                             message: '"persnicketyField" length must be less than or equal to 1 characters long',
-                            keyword: 'string.max',
-                            params: {
+                            type: 'string.max',
+                            data: {
                                 limit: 1,
                                 value: 'xxxxx',
                                 encoding: undefined,
@@ -1371,8 +1371,8 @@ describe('Schwifty', () => {
                         },
                         {
                             message: '"persnicketyField" length must be at least 10 characters long',
-                            keyword: 'string.min',
-                            params: {
+                            type: 'string.min',
+                            data: {
                                 limit: 10,
                                 value: 'xxxxx',
                                 encoding: undefined,

--- a/test/index.js
+++ b/test/index.js
@@ -1360,8 +1360,8 @@ describe('Schwifty', () => {
                     persnicketyField: [
                         {
                             message: '"persnicketyField" length must be less than or equal to 1 characters long',
-                            joiType: 'string.max',
-                            data: {
+                            keyword: 'string.max',
+                            params: {
                                 limit: 1,
                                 value: 'xxxxx',
                                 encoding: undefined,
@@ -1371,8 +1371,8 @@ describe('Schwifty', () => {
                         },
                         {
                             message: '"persnicketyField" length must be at least 10 characters long',
-                            joiType: 'string.min',
-                            data: {
+                            keyword: 'string.min',
+                            params: {
                                 limit: 10,
                                 value: 'xxxxx',
                                 encoding: undefined,

--- a/test/index.js
+++ b/test/index.js
@@ -1360,7 +1360,7 @@ describe('Schwifty', () => {
                     persnicketyField: [
                         {
                             message: '"persnicketyField" length must be less than or equal to 1 characters long',
-                            type: 'string.max',
+                            joiType: 'string.max',
                             data: {
                                 limit: 1,
                                 value: 'xxxxx',
@@ -1371,7 +1371,7 @@ describe('Schwifty', () => {
                         },
                         {
                             message: '"persnicketyField" length must be at least 10 characters long',
-                            type: 'string.min',
+                            joiType: 'string.min',
                             data: {
                                 limit: 10,
                                 value: 'xxxxx',


### PR DESCRIPTION
Upgrades this sucka to Objection v.1

Only breaking change from the changelog that affected us (at least our current test suite) was the overhaul to the ValidationError interface, which just necessitated changing how we were mapping Joi errors to Objection errors. 

Bonus points to anyone who can explain this magic to me :trollface: :  https://github.com/Vincit/objection.js/blob/master/lib/model/ValidationError.js#L29

How can you pass a single param to map? Seems like this works by map expecting and nabbing the message property of the passed object? This worked only when run within Objection, when I pulled it out to try to test in isolation (pasted necessary functions into a new file, I got a reference error, saying `message` was undefined).
