### PR TITLE
Use knex v0.16+ native migrator to support multiple directories

### DIFF
--- a/API.md
+++ b/API.md
@@ -2,7 +2,7 @@
 
 > **Note**
 >
-> Schwifty is intended for use with hapi v17+, joi v16+, Objection v1 and v2, knex v0.8+, and nodejs v8+.
+> Schwifty is intended for use with hapi v17+, joi v16+, Objection v1 and v2, knex v0.16+, and nodejs v8+.
 
 ## The hapi plugin
 ### Registration

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Schwifty is used to define [Joi](https://github.com/hapijs/joi)-compatible model
 
 > **Note**
 >
-> Schwifty is intended for use with hapi v17+, joi v16+, Objection v1 and v2, knex v0.8+, and nodejs v8+.
+> Schwifty is intended for use with hapi v17+, joi v16+, Objection v1 and v2, knex v0.16+, and nodejs v8+.
 
 ```js
 // First, ensure your project includes knex, objection, and sqlite3

--- a/lib/migrator.js
+++ b/lib/migrator.js
@@ -1,13 +1,6 @@
 'use strict';
 
-const Fs = require('fs');
-const Path = require('path');
-const Tmp = require('tmp');
-const Util = require('util');
-
-const internals = {
-    SUPPORTED_EXTENSIONS: ['.co', '.coffee', '.eg', '.iced', '.js', '.litcoffee', '.ls', '.ts'] // from knex
-};
+const internals = {};
 
 exports.migrate = async (migrations, rollback) => {
 
@@ -18,62 +11,7 @@ exports.migrate = async (migrations, rollback) => {
 
 internals.executeMigration = async (knex, migrationsDirs, rollback) => {
 
-    // Promisifying callback-style functions at runtime allows us to monkey-patch these methods in our tests to simulate errors.  See /test/index.js, migrations tests usage of Fs.readdir and Tmp.dir.
-    const { tmpPath, tmpCleanup } = await internals.tmpDir({ unsafeCleanup: true });
+    const latestOrRollback = rollback ? 'rollback' : 'latest';
 
-    try {
-
-        await Promise.all(
-            migrationsDirs.map(
-                (migrationsDir) => internals.symlinkMigrationFiles(migrationsDir, tmpPath)
-            )
-        );
-
-        const relMigrationsDir = Path.relative(process.cwd(), tmpPath);
-        const latestOrRollback = rollback ? 'rollback' : 'latest';
-
-        await knex.migrate[latestOrRollback]({ directory: relMigrationsDir });
-    }
-    finally {
-        // Any errors in the try block will still be thrown
-        // Cleanup the temp dir (remove it _recursively_ due to unsafeCleanup option)
-        tmpCleanup();
-    }
-};
-
-internals.symlinkMigrationFiles = async (migrationsDir, tmpPath) => {
-
-    const migrationFiles = await Util.promisify(Fs.readdir)(migrationsDir);
-
-    await Promise.all(
-        migrationFiles.map((file) => internals.createSymlink(file, migrationsDir, tmpPath))
-    );
-};
-
-internals.createSymlink = async (migrationFile, migrationsDir, tmpPath) => {
-
-    if (internals.SUPPORTED_EXTENSIONS.indexOf(Path.extname(migrationFile)) === -1) {
-        return;
-    }
-
-    const file = Path.join(migrationsDir, migrationFile);
-    const link = Path.join(tmpPath, migrationFile);
-
-    await Util.promisify(Fs.symlink)(file, link);
-};
-
-// Special promisification of Tmp.dir() since it callsback with two values
-internals.tmpDir = (opts) => {
-
-    return new Promise((resolve, reject) => {
-
-        Tmp.dir(opts, (err, tmpPath, tmpCleanup) => {
-
-            if (err) {
-                return reject(err);
-            }
-
-            return resolve({ tmpPath, tmpCleanup });
-        });
-    });
+    await knex.migrate[latestOrRollback]({ directory: migrationsDirs });
 };

--- a/package.json
+++ b/package.json
@@ -28,13 +28,12 @@
   "dependencies": {
     "@hapi/hoek": "8.x.x",
     "@hapi/joi": "15.x.x",
-    "tmp": "0.1.x",
     "toys": "2.x.x"
   },
   "peerDependencies": {
     "@hapi/hapi": ">=17 <19",
     "@hapi/joi": ">=14 <16",
-    "knex": ">=0.8",
+    "knex": ">=0.16",
     "objection": ">=1 <2"
   },
   "devDependencies": {

--- a/test/index.js
+++ b/test/index.js
@@ -2,9 +2,7 @@
 
 // Load modules
 
-const Fs = require('fs');
 const Path = require('path');
-const Tmp = require('tmp');
 const Lab = require('@hapi/lab');
 const Code = require('@hapi/code');
 const Hapi = require('@hapi/hapi');
@@ -995,51 +993,6 @@ describe('Schwifty', () => {
 
             // If 2nd-bad had run, that would be the current version due to sort order
             expect(version).to.equal('1st-good.js');
-        });
-
-        it('bails when failing to make a temp migrations directory.', async () => {
-
-            const server = await getServer(getOptions({
-                migrationsDir: './test/migrations/basic',
-                migrateOnStart: true
-            }));
-
-            // Monkey-patches Tmp.dir to simulate an error in that method
-            const origTmpDir = Tmp.dir;
-            Tmp.dir = (opts, cb) => {
-
-                // Reverts Tmp.dir back to its original definition, so subsequent tests use the normal function
-                Tmp.dir = origTmpDir;
-                cb(new Error('Generating temp dir failed.'));
-            };
-
-            // We expect server initialization to fail with the simulated Tmp error message
-            await expect(server.initialize()).to.reject('Generating temp dir failed.');
-
-            const version = await server.knex().migrate.currentVersion();
-            expect(version).to.equal('none');
-        });
-
-        it('bails when failing to read a migrations directory.', async () => {
-
-            const server = await getServer(getOptions({
-                migrationsDir: './test/migrations/basic',
-                migrateOnStart: true
-            }));
-
-            // Monkey-patches Fs.readdir to simulate an error in that method
-            const origReaddir = Fs.readdir;
-            Fs.readdir = (opts, cb) => {
-
-                // Reverts Fs.readdir back to its original definition, so subsequent tests use the normal function
-                Fs.readdir = origReaddir;
-                cb(new Error('Reading migrations dir failed.'));
-            };
-
-            await expect(server.initialize()).to.reject('Reading migrations dir failed.');
-
-            const version = await server.knex().migrate.currentVersion();
-            expect(version).to.equal('none');
         });
     });
 


### PR DESCRIPTION
As of knex v0.16, multiple migration directories are natively supported.  So now we don't have to do hack around that limitation with temp directories, as we've currently been doing!  Feels good :) Resolves #60.