### PR TITLE
Implement helper to extract per-field validation

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -40,6 +40,19 @@ module.exports = class SchwiftyModel extends Objection.Model {
         return schema;
     }
 
+    static field(name) {
+
+        const fullSchema = this.getJoiSchema().extract(name);
+
+        return fullSchema
+            .optional()
+            .prefs({ noDefaults: true })
+            .alter({
+                full: () => fullSchema,
+                patch: (schema) => schema
+            });
+    }
+
     // Applies default jsonAttributes based upon joiSchema,
     // otherwise fallsback to however jsonAttributes has been set
     static get jsonAttributes() {

--- a/test/index.js
+++ b/test/index.js
@@ -1513,6 +1513,96 @@ describe('Schwifty', () => {
             });
         });
 
+        describe('static method field(name)', () => {
+
+            it('tailors a patch version of the field validation by default.', () => {
+
+                const Model = class extends Schwifty.Model {
+                    static get joiSchema() {
+
+                        return Joi.object({
+                            a: Joi.string().min(3),
+                            b: Joi.string().default('b'),
+                            c: Joi.string().required()
+                        });
+                    }
+                };
+
+                const a = Model.field('a');
+                const b = Model.field('b');
+                const c = Model.field('c');
+
+                expect(a.validate('123')).to.equal({ value: '123' });
+                expect(a.validate('12')).to.contain('error');
+
+                expect(b.validate()).to.equal({ value: undefined });
+                expect(b.validate('x')).to.equal({ value: 'x' });
+                expect(b.validate(1)).to.contain('error');
+
+                expect(c.validate()).to.equal({ value: undefined });
+                expect(c.validate('x')).to.equal({ value: 'x' });
+                expect(c.validate(1)).to.contain('error');
+            });
+
+            it('has a no-op "patch" schema alteration.', () => {
+
+                const Model = class extends Schwifty.Model {
+                    static get joiSchema() {
+
+                        return Joi.object({
+                            a: Joi.string().min(3),
+                            b: Joi.string().default('b'),
+                            c: Joi.string().required()
+                        });
+                    }
+                };
+
+                const a = Model.field('a').tailor('patch');
+                const b = Model.field('b').tailor('patch');
+                const c = Model.field('c').tailor('patch');
+
+                expect(a.validate('123')).to.equal({ value: '123' });
+                expect(a.validate('12')).to.contain('error');
+
+                expect(b.validate()).to.equal({ value: undefined });
+                expect(b.validate('x')).to.equal({ value: 'x' });
+                expect(b.validate(1)).to.contain('error');
+
+                expect(c.validate()).to.equal({ value: undefined });
+                expect(c.validate('x')).to.equal({ value: 'x' });
+                expect(c.validate(1)).to.contain('error');
+            });
+
+            it('has a "full" schema alteration.', () => {
+
+                const Model = class extends Schwifty.Model {
+                    static get joiSchema() {
+
+                        return Joi.object({
+                            a: Joi.string().min(3),
+                            b: Joi.string().default('b'),
+                            c: Joi.string().required()
+                        });
+                    }
+                };
+
+                const a = Model.field('a').tailor('full');
+                const b = Model.field('b').tailor('full');
+                const c = Model.field('c').tailor('full');
+
+                expect(a.validate('123')).to.equal({ value: '123' });
+                expect(a.validate('12')).to.contain('error');
+
+                expect(b.validate()).to.equal({ value: 'b' });
+                expect(b.validate('x')).to.equal({ value: 'x' });
+                expect(b.validate(1)).to.contain('error');
+
+                expect(c.validate()).to.contain('error');
+                expect(c.validate('x')).to.equal({ value: 'x' });
+                expect(c.validate(1)).to.contain('error');
+            });
+        });
+
         describe('static getter jsonAttributes', () => {
 
             it('lists attributes that are specified as Joi objects or arrays.', () => {

--- a/test/index.js
+++ b/test/index.js
@@ -1602,7 +1602,7 @@ describe('Schwifty', () => {
                 expect(c.validate(1)).to.contain('error');
             });
 
-            it('supports nested properties', () => {
+            it('supports nested properties.', () => {
 
                 const Model = class extends Schwifty.Model {
                     static get joiSchema() {
@@ -1639,7 +1639,7 @@ describe('Schwifty', () => {
                 expect(efull.validate(1)).to.contain('error');
             });
 
-            it('throws when called on a field whose schema contains a ref', () => {
+            it('validation throws when the schema contains an invalid ref', () => {
 
                 const Model = class extends Schwifty.Model {
                     static get joiSchema() {
@@ -1662,6 +1662,12 @@ describe('Schwifty', () => {
                 expect(b.validate(6)).to.equal({ value: 6 });
                 expect(() => c.validate(5)).to.throw('Invalid reference exceeds the schema root: ref:a');
                 expect(() => d.validate(30)).to.throw('Invalid reference exceeds the schema root: ref:b');
+
+                const schema = Joi.object({
+                    a: Joi.string(),
+                    c
+                });
+                expect(schema.validate({ a: '123', c: '123' })).to.equal({ value: { a: '123', c: '123' } });
             });
         });
 

--- a/test/index.js
+++ b/test/index.js
@@ -1639,7 +1639,7 @@ describe('Schwifty', () => {
                 expect(efull.validate(1)).to.contain('error');
             });
 
-            it('validation throws when the schema contains an invalid ref', () => {
+            it('validation throws when the schema contains an invalid ref.', () => {
 
                 const Model = class extends Schwifty.Model {
                     static get joiSchema() {


### PR DESCRIPTION
We have found it very common to add a helper to our base schema in order to extract per-field validation schemas, e.g. for use in route validation config.  For example, see here in the realworld app: https://github.com/devinivy/hapipal-realworld-example-app/blob/727c797a5946f24f69edbfce789a32289f382d54/lib/models/helpers/index.js#L16-L22 https://github.com/devinivy/hapipal-realworld-example-app/blob/727c797a5946f24f69edbfce789a32289f382d54/lib/routes/articles/fetch.js#L11-L15

This PR adds exactly such a helper to `Schwifty.Model`!  The main opinion baked into this work is that the extracted fields should be prepared for a "patch" by default: that means that the field's default value and required/optional/forbidden status is ignored.  To make up for this, we provide two joi [alterations](https://hapi.dev/family/joi/#anyaltertargets): `'full'` and `'patch'`.  The latter `'patch'` is just an explicit name for the default behavior.  The former `'full'` restores the field's default value and required/optional/forbidden status.