### PR TITLE
Tailor for 'patch' if it exists

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -154,7 +154,7 @@ internals.patchSchema = (schema) => {
     // Make all keys optional, do not enforce defaults
 
     if (keys.length) {
-        schema = schema.fork(keys, (s) => s.optional());
+        schema = schema.tailor('patch').fork(keys, (s) => s.optional());
     }
 
     return schema.prefs({ noDefaults: true });


### PR DESCRIPTION
[tailor](https://github.com/hapijs/joi/blob/a7102c60ad1cecba70c60c477169b2f1204e67d4/lib/base.js#L505) seems to be fine handling the case where you haven't specified an alteration with the name of what you're looking to tailor, so I think we can just do this for all patch schemas. Thoughts?