### PR TITLE
Namespaces, sandboxing, and optional knex binding

### DIFF
--- a/API.md
+++ b/API.md
@@ -117,7 +117,7 @@ Then we can say the following,
 Schwifty performs a few important routines during server initialization.
 
 #### Binding models to knex
-First, models are bound to instances of knex on a per-plugin basis.  Each model is bound to the knex instance of the plugin—under [plugin ownership of knex instances](#knex-instances)—in which the model was defined.  If a model already is bound to a knex instance prior to initialization, it will not be bound to a new one.
+First, models are bound to instances of knex on a per-plugin basis.  Each model is bound to the knex instance of the plugin—under [plugin ownership of knex instances](#knex-instances)—in which the model was defined.  If a model already is bound to a knex instance prior to initialization, it will not be bound to a new one.  Additionally, if a model's [`Schwifty.bindKnex`](#schwiftybindknex) property is `false` then it will not be bound.
 
 This means that prior to server initialization, calls to [`server.models()`](#servermodelsnamespace) will provide models that will not be bound to a knex instance (unless you've done so manually).  If you would like to perform some tasks during server initialization that rely on database-connected models, simply tell your `onPreStart` server extension to occur after schwifty, e.g.,
 ```js
@@ -207,3 +207,7 @@ A symbol that may be added as a property to a knex instance or a model in order 
 Sandboxing ensures that the object in question opts out of transitive ownership as described in ["Plugin ownership of knex instances and models"](#plugin-ownership-of-knex-instances-and-models), and in turn is only visible within the plugin where it is provided.
 
 When this property is set to `true` or `'plugin'` the object will be sandboxed. The default behavior of plugin ownership can be explicitly configured using the value `false` or `'server'`.
+
+### `Schwifty.bindKnex`
+
+A symbol that may be added as a property to a model in order to opt-out of [knex-binding during server initialization](#binding-models-to-knex).  When this property is set to `false`, a knex instance will not automatically be bound to the model.

--- a/API.md
+++ b/API.md
@@ -27,27 +27,33 @@ Used to declare models, knex instances, and migration directory information on a
     - `models` - An array of objection or [schwifty model classes](#schwiftymodel) associated with the current plugin or root server.
     - `migrationsDir` - specifies a directory of knex migrations associated with the current plugin or root server.  The directory path may be either absolute, relative to the plugin's [path prefix](https://hapi.dev/api/#server.path()) when set, or otherwise relative to the current working directory.  It cannot be specified more than once within a plugin or on the root server.
 
-#### `server.knex()`
-Returns `server`'s knex instance under schwifty's [plugin ownership of knex instances](#knex-instances).
+#### `server.knex([namespace])`
+Returns `server`'s knex instance.
 
-#### `server.models([all])`
-Returns an object containing models keyed by their `name`.  Includes `server`'s models based upon schwifty's [plugin ownership of models](#models).  When `all` is `true`, models across the entire server are returned.
+Per schwifty's [plugin ownership of knex instances](#knex-instances), this is the knex instance provided by `server` or the nearest knex instance among `server`'s ancestors (e.g. if `server` is within a plugin that has been registered by a separate plugin that provides a knex instance) that is also not [sandboxed](#sandboxing).
+
+By passing a `namespace` you can obtain knex instance from the perspective of a different plugin. When `namespace` is a string, you receive the knex instance that is visibile within the plugin named `namespace`. And when `namespace` is `true`, you receive the knex instance that is visible to the root server.
+
+#### `server.models([namespace])`
+Returns an object containing models keyed by their `name`.
+
+Per schwifty's [plugin ownership of models](#models), the models that are available on this object are only those registered by `server` or any plugins for which `server` is an ancestor (e.g. if `server` has registered a plugin that registers models) that are also not [sandboxed](#sandboxing).
+
+By passing a `namespace` you can obtain the models from the perspective of a different plugin. When `namespace` is a string, you receive models that are visibile within the plugin named `namespace`. And when `namespace` is `true`, you receive models that are visible to the root server: every model registered with the hapi server– across all plugins– that isn't sandboxed.
 
 ### Request decorations
-#### `request.knex()`
-Returns knex instance under schwifty's [plugin ownership of knex instances](#knex-instances), where the active plugin is the one in which the `request`'s route was declared (i.e. based upon `request.route.realm`).
-
+#### `request.knex([namespace])`
+Returns a knex instance.  See [`server.knex()`](#serverknexnamespace), where `server` is the one in which the `request`'s route was declared (i.e. based upon `request.route.realm`).
 
 #### `request.models([all])`
-Returns an object containing models keyed by their `name`.  Includes models based upon schwifty's [plugin ownership of models](#models), where the active plugin is the one in which the `request`'s route was declared (i.e. based upon `request.route.realm`).  When `all` is `true`, models across the entire server are returned.
-
+Returns an object containing models keyed by their `name`.  See [`server.models()`](#servermodelsnamespace), where `server` is the one in which the `request`'s route was declared (i.e. based upon `request.route.realm`).
 
 ### Response toolkit decorations
-#### `h.knex()`
-Returns knex instance under schwifty's [plugin ownership of knex instances](#knex-instances), where the active plugin is the one in which the corresponding route or server extension was declared (i.e. based upon `h.realm`).
+#### `h.knex([namespace])`
+Returns a knex instance.  See [`server.knex()`](#serverknexnamespace), where `server` is the one in which the corresponding route or server extension was declared (i.e. based upon `h.realm`).
 
-#### `h.models([all])`
-Returns an object containing models keyed by their `name`.  Includes models based upon schwifty's [plugin ownership of models](#models), where the active plugin is the one in which the corresponding route or server extension was declared (i.e. based upon `h.realm`).  When `all` is `true`, models across the entire server are returned.
+#### `h.models([namespace])`
+Returns an object containing models keyed by their `name`.  See [`server.models()`](#servermodelsnamespace), where `server` is the one in which the corresponding route or server extension was declared (i.e. based upon `h.realm`).
 
 
 ### Plugin ownership of knex instances and models
@@ -56,18 +62,39 @@ Returns an object containing models keyed by their `name`.  Includes models base
 Schwifty cares a whole lot about plugin boundaries.  Plugins represent the structure of your application, and we think that's not only practical but also very meaningful.  Under schwifty plugins declare knex instances and models, and actually retain _ownership_ of them in a useful way that respects your application's plugin boundaries.
 
 #### Knex instances
-Whenever a plugin or the root server configures a knex instance, either by [registering](#registration) schwifty and passing `knex` or calling [`server.schwifty({ knex })`](#serverschwiftyconfig), an instance of knex is attributed to that plugin.  Consider `plugin-x` that declares a knex instance.  It becomes available by calling [`server.knex()`](#serverknex) within `plugin-x`, or [`request.knex()`](#requestknex) within one of `plugin-x`'s routes.  But it goes further!  This instance of knex is also available to all plugins _registered by_ `plugin-x` that do not have their own knex instances.
+Whenever a plugin or the root server configures a knex instance, either by [registering](#registration) schwifty and passing `knex` or calling [`server.schwifty({ knex })`](#serverschwiftyconfig), an instance of knex is attributed to that plugin.  Consider `plugin-x` that declares a knex instance.  It becomes available by calling [`server.knex()`](#serverknexnamespace) within `plugin-x`, or [`request.knex()`](#requestknexnamespace) within one of `plugin-x`'s routes.  But it goes further!  This instance of knex is also available to all plugins _registered by_ `plugin-x` that do not have their own knex instances.
 
 This allows us to handle very common use-cases, e.g. a single knex/database is configured on the root server: all other plugins using schwifty are registered under the root server and automatically inherit that database configuration.  But it also allows us to handle complex cases, e.g. multiple applications with their own knex/databases all being deployed together as separate plugins on a single hapi server.
 
 #### Models
-Whenever a plugin or the root server declares some models, either by [registering](#registration) schwifty and passing `models` or calling [`server.schwifty(models)`](#serverschwiftyconfig), those models are attributed to that plugin.  Consider `plugin-x` registering plugin `plugin-a`, which declares the model `Pets`.  Inside `plugin-a` the `Pets` model is available by calling [`server.models()`](#servermodelsall) within `plugin-a`, or [`request.models()`](#requestmodelsall) within one of `plugin-a`'s routes.  But, just as with [knex instances](#knex-instances), it goes further!  `Pets` is also available to `plugin-x` since it registered `plugin-a`.  In fact, `Pets` is available to the entire plugin chain up to the root server.  In this way, the root server will have access to every model declared by any plugin.
+Whenever a plugin or the root server declares some models, either by [registering](#registration) schwifty and passing `models` or calling [`server.schwifty(models)`](#serverschwiftyconfig), those models are attributed to that plugin.  Consider `plugin-x` registering plugin `plugin-a`, which declares the model `Pets`.  Inside `plugin-a` the `Pets` model is available by calling [`server.models()`](#servermodelsnamespace) within `plugin-a`, or [`request.models()`](#requestmodelsnamespace) within one of `plugin-a`'s routes.  But, just as with [knex instances](#knex-instances), it goes further!  `Pets` is also available to `plugin-x` since it registered `plugin-a`.  In fact, `Pets` is available to the entire plugin chain up to the root server.  In this way, the root server will have access to every model declared by any plugin (barring [sandboxing](#sandboxing)).
 
 This allows us to handle very common use-cases, e.g. a plugin simply wants to declare and use some models.  But it also allows us to handle complex cases, e.g. authoring a plugin that declares some models that you would like to reuse across multiple applications.
 
 Note that the [schmervice](https://github.com/hapipal/schmervice) plugin deals with plugin ownership of services in exactly the same way.
 
-> As an escape hatch, you can always call [`server.models(true)`](#servermodelsall) (passing `true` to any of the server, request, or response toolkit's `models()` decoration) to break the plugin boundary and access any model declared by any plugin on the entire server.
+> As an escape hatch, you can always call [`server.models(true)`](#servermodelsnamespace) (passing `true` to any of the server, request, or response toolkit's `models()` decoration) to break the plugin boundary and access models declared by any plugin on the entire server.  You may similarly pass a plugin name in order to access models from the perspective of that specific plugin, e.g. `server.models('my-plugin')`.
+
+#### Sandboxing
+When a model or knex instance is "sandboxed", it is only visible within the plugin that directly provides it.  This is a form of opting-out of transitive ownership of models and knex instances described in the previous two sections.  However, sandboxed models and knex instances can still be accessed from other plugins using the `namespace` parameter as described in [`server.models([namespace])`](#servermodelsnamespace) and [`server.knex([namespace])`](#serverknexnamespace)
+
+In order to sandbox a model, set the [`Schwifty.sandbox`](#schwiftysandbox) property to `true` on it statically (you may also use a getter):
+
+```js
+class User extends Schwifty.Model {
+    static tableName = 'Users';
+    static [Schwifty.sandbox] = true;
+};
+```
+
+Similarly, in order to sandbox a knex instance, set its [`Schwifty.sandbox`](#schwiftysandbox) property to `true`:
+
+```js
+const knex = Knex({ client: 'sqlite3' });
+knex[Schwifty.sandbox] = true;
+```
+
+> In order to make ensure that this property doesn't conflict with Objection or Knex internals, `Schwifty.sandbox` is a symbol.
 
 #### An example
 Consider two plugins, `plugin-a` and `plugin-b`,
@@ -92,7 +119,7 @@ Schwifty performs a few important routines during server initialization.
 #### Binding models to knex
 First, models are bound to instances of knex on a per-plugin basis.  Each model is bound to the knex instance of the plugin—under [plugin ownership of knex instances](#knex-instances)—in which the model was defined.  If a model already is bound to a knex instance prior to initialization, it will not be bound to a new one.
 
-This means that prior to server initialization, calls to [`server.models()`](#servermodelsall) will provide models that will not be bound to a knex instance (unless you've done so manually).  If you would like to perform some tasks during server initialization that rely on database-connected models, simply tell your `onPreStart` server extension to occur after schwifty, e.g.,
+This means that prior to server initialization, calls to [`server.models()`](#servermodelsnamespace) will provide models that will not be bound to a knex instance (unless you've done so manually).  If you would like to perform some tasks during server initialization that rely on database-connected models, simply tell your `onPreStart` server extension to occur after schwifty, e.g.,
 ```js
 server.ext('onPreStart', someDbConnectedTask, { after: 'schwifty' });
 ```
@@ -153,7 +180,8 @@ User.field('username').tailor('full').validate('paldo');  // { value: 'paldo' }
 ### `model.$validate()`
 Validates the model instance using its [`joiSchema`](#joischema).  This is implemented using objection's [`Validator`](https://vincit.github.io/objection.js/api/types/#class-validator) interface.
 
-## Utilities
+## Utilities and Symbols
+
 ### `Schwifty.assertCompatible(ModelA, ModelB, [message])`
 Ensures that `ModelA` and `ModelB` have the same class `name`, share the same `tableName`, and that one model extends the other, otherwise throws an error.  When `message` is provided, it will be used as the message for any thrown error.
 
@@ -171,3 +199,11 @@ module.exports = {
     }
 };
 ```
+
+### `Schwifty.sandbox`
+
+A symbol that may be added as a property to a knex instance or a model in order to participate in [sandboxing](#sandboxing).
+
+Sandboxing ensures that the object in question opts out of transitive ownership as described in ["Plugin ownership of knex instances and models"](#plugin-ownership-of-knex-instances-and-models), and in turn is only visible within the plugin where it is provided.
+
+When this property is set to `true` or `'plugin'` the object will be sandboxed. The default behavior of plugin ownership can be explicitly configured using the value `false` or `'server'`.

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,0 +1,41 @@
+'use strict';
+
+exports.symbols = {};
+
+exports.symbols.sandbox = Symbol('schwiftySandbox');
+
+exports.getName = (Model) => Model.name;
+
+exports.getSandbox = (obj) => {
+
+    const sandbox = obj[exports.symbols.sandbox];
+
+    if (sandbox === 'plugin') {
+        return true;
+    }
+
+    if (sandbox === 'server') {
+        return false;
+    }
+
+    return sandbox;
+};
+
+exports.setNonEnumerableProperty = (obj, prop, value) => {
+
+    Object.defineProperty(obj, prop, {
+        enumerable: false,
+        writable: true,
+        configurable: true,
+        value
+    });
+};
+
+exports.copyDescriptor = (name, from, to) => {
+
+    const descriptor = Object.getOwnPropertyDescriptor(from, name);
+
+    if (descriptor) {
+        Object.defineProperty(to, name, descriptor);
+    }
+};

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -4,6 +4,8 @@ exports.symbols = {};
 
 exports.symbols.sandbox = Symbol('schwiftySandbox');
 
+exports.symbols.bindKnex = Symbol('schwiftyBindKnex');
+
 exports.getName = (Model) => Model.name;
 
 exports.getSandbox = (obj) => {
@@ -20,6 +22,8 @@ exports.getSandbox = (obj) => {
 
     return sandbox;
 };
+
+exports.getBindKnex = (Model) => Model[exports.symbols.bindKnex] !== false;
 
 exports.setNonEnumerableProperty = (obj, prop, value) => {
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -38,18 +38,10 @@ exports.plugin = {
 
         Joi.assert(options, Schema.plugin, 'Bad plugin options passed to schwifty.');
 
-        const parentRealm = server.realm.parent;
-        const rootState = internals.rootState(server.realm);
+        const { realm } = server;
+        const rootState = internals.rootState(realm);
 
         if (!rootState.setup) {
-
-            rootState.collector = {
-                teardownOnStop: null,   // Not set, effectively defaults true
-                migrateOnStart: null,   // Not set, effectively defaults false
-                realmByModel: new Map(),
-                realmsWithMigrationsDir: new Set(),
-                knexes: new Set()
-            };
 
             server.decorate('server', 'schwifty', function (config) {
 
@@ -67,24 +59,24 @@ exports.plugin = {
             rootState.setup = true;
         }
 
-        const rootCollector = rootState.collector;
+        const { collector } = rootState;
 
         // Decide whether server stop should teardown
 
         if (typeof options.teardownOnStop !== 'undefined') {
-            Hoek.assert(rootCollector.teardownOnStop === null, 'Schwifty\'s teardownOnStop option can only be specified once.');
-            rootCollector.teardownOnStop = options.teardownOnStop;
+            Hoek.assert(collector.teardownOnStop === null, 'Schwifty\'s teardownOnStop option can only be specified once.');
+            collector.teardownOnStop = options.teardownOnStop;
         }
 
         // Decide whether server start should perform migrations
 
         if (typeof options.migrateOnStart !== 'undefined') {
-            Hoek.assert(rootCollector.migrateOnStart === null, 'Schwifty\'s migrateOnStart option can only be specified once.');
-            rootCollector.migrateOnStart = options.migrateOnStart;
+            Hoek.assert(collector.migrateOnStart === null, 'Schwifty\'s migrateOnStart option can only be specified once.');
+            collector.migrateOnStart = options.migrateOnStart;
         }
 
         const config = internals.registrationConfig(options);
-        internals.schwifty(parentRealm, config);
+        internals.schwifty(realm.parent, config);
     }
 };
 
@@ -102,12 +94,16 @@ internals.initialize = async (server) => {
 
     const { collector } = internals.rootState(server.realm);
 
-    collector.realmByModel.forEach((realm, Model) => {
+    // Spread realmByModel into a concrete array, so we can safely mutate it while iterating over it
+    ([...collector.realmByModel]).forEach(([Model, realm]) => {
 
         const knex = internals.knex(() => realm)();
         const BoundModel = (knex && !Model.knex()) ? Model.bindKnex(knex) : Model;
         const name = internals.getName(Model);
         const sandbox = internals.getSandbox(Model);
+
+        collector.realmByModel.delete(Model);
+        collector.realmByModel.set(BoundModel, realm);
 
         if (sandbox) {
             return internals.addModelToRealm(realm, BoundModel, name, { override: true });
@@ -128,17 +124,20 @@ internals.initialize = async (server) => {
         }
         catch (err) {
 
-            const models = internals.models(() => server.realm)(true);
-            const modelNames = Object.values(models)
-                .filter((Model) => Model.knex() === knex)
-                .map(internals.getName);
+            const modelInfo = [...collector.realmByModel]
+                .filter(([Model]) => Model.knex() === knex)
+                .map(([Model, realm]) => ({
+                    name: internals.getName(Model),
+                    sandbox: internals.getSandbox(Model),
+                    namespace: realm.plugin
+                }));
 
             // Augment original error message
 
-            const quoted = (x) => `"${x}"`;
+            const displayInfo = ({ name, sandbox, namespace }) => `"${name}"${sandbox ? ` (${namespace})` : ''}`;
 
             let message = 'Could not connect to database using schwifty knex instance';
-            message += modelNames.length ? ` for models: ${modelNames.map(quoted).join(', ')}.` : '.';
+            message += modelInfo.length ? ` for models: ${modelInfo.map(displayInfo).join(', ')}.` : '.';
             err.message = (message + (err.message ? ': ' + err.message : ''));
 
             throw err;
@@ -241,20 +240,19 @@ internals.schwifty = (realm, config) => {
 
 internals.models = (getRealm) => {
 
-    return function (all) {
+    return function (namespace) {
 
-        const realm = getRealm(this);
-        const { models } = all ? internals.rootState(realm) : internals.state(realm);
+        const realm = internals.getRealmFromNamespace(getRealm(this), namespace);
 
-        return models || {};
+        return internals.state(realm).models;
     };
 };
 
 internals.knex = (getRealm) => {
 
-    return function () {
+    return function (namespace) {
 
-        const realm = getRealm(this);
+        const realm = internals.getRealmFromNamespace(getRealm(this), namespace);
 
         let knex;
         let iterateRealm = realm;
@@ -264,6 +262,8 @@ internals.knex = (getRealm) => {
             const state = internals.state(iterateRealm);
 
             knex = state.knex;
+
+            // Skip any knexes outside the given namespace that are sandboxed
             if (knex && internals.getSandbox(knex) && iterateRealm !== realm) {
                 knex = null;
             }
@@ -273,6 +273,23 @@ internals.knex = (getRealm) => {
 
         return knex || null;
     };
+};
+
+internals.getRealmFromNamespace = (realm, namespace) => {
+
+    if (!namespace) {
+        return realm;
+    }
+
+    if (typeof namespace === 'string') {
+        const namespaceSet = internals.rootState(realm).namespaces[namespace];
+        Hoek.assert(namespaceSet, `The plugin namespace ${namespace} does not exist.`);
+        Hoek.assert(namespaceSet.size === 1, `The plugin namespace ${namespace} is not unique: is that plugin registered multiple times?`);
+        const [namespaceRealm] = [...namespaceSet];
+        return namespaceRealm;
+    }
+
+    return Toys.rootRealm(realm);
 };
 
 internals.stop = async (server) => {
@@ -323,8 +340,7 @@ internals.state = (realm) => {
         Object.assign(state, {
             models: {},
             migrationsDir: null,    // If present, will be resolved to an absolute path
-            knex: null,
-            namespaces: {}
+            knex: null
         });
     }
 
@@ -334,6 +350,21 @@ internals.state = (realm) => {
 internals.rootState = (realm) => {
 
     const rootRealm = Toys.rootRealm(realm);
+    const state = internals.state(rootRealm);
 
-    return internals.state(rootRealm);
+    if (!state.hasOwnProperty('setup')) {
+        Object.assign(state, {
+            setup: false,
+            namespaces: {},
+            collector: {
+                teardownOnStop: null,   // Not set, effectively defaults true
+                migrateOnStart: null,   // Not set, effectively defaults false
+                realmByModel: new Map(),
+                realmsWithMigrationsDir: new Set(),
+                knexes: new Set()
+            }
+        });
+    }
+
+    return state;
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -30,6 +30,8 @@ exports.assertCompatible = (A, B, msg) => {
 
 exports.sandbox = Helpers.symbols.sandbox;
 
+exports.bindKnex = Helpers.symbols.bindKnex;
+
 exports.plugin = {
     pkg: Package,
     multiple: true,
@@ -99,7 +101,8 @@ internals.initialize = async (server) => {
     ([...collector.realmByModel]).forEach(([Model, realm]) => {
 
         const knex = internals.knex(() => realm)();
-        const BoundModel = (knex && !Model.knex()) ? Model.bindKnex(knex) : Model;
+        const bindKnex = Helpers.getBindKnex(Model);
+        const BoundModel = (knex && bindKnex && !Model.knex()) ? Model.bindKnex(knex) : Model;
         const name = Helpers.getName(Model);
         const sandbox = Helpers.getSandbox(Model);
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -76,6 +76,8 @@ exports.plugin = {
         }
 
         const config = internals.registrationConfig(options);
+
+        // This should always run, even for plugins without options in order to remember the namespace
         internals.schwifty(realm.parent, config);
     }
 };
@@ -198,6 +200,8 @@ internals.schwifty = (realm, config) => {
     const state = internals.state(realm);
     const rootState = internals.rootState(realm);
 
+    internals.setNamespaceFromRealm(rootState, realm);
+
     config.models.forEach((Model) => {
 
         const name = internals.getName(Model);
@@ -206,8 +210,6 @@ internals.schwifty = (realm, config) => {
         Hoek.assert(name, 'Every model class must have a name.');
         Hoek.assert(sandbox || !rootState.models[name], `Model "${name}" has already been registered.`);
 
-        rootState.namespaces[realm.plugin] = rootState.namespaces[realm.plugin] || new Set();
-        rootState.namespaces[realm.plugin].add(realm);
         rootState.collector.realmByModel.set(Model, realm);
 
         if (sandbox) {
@@ -290,6 +292,15 @@ internals.getRealmFromNamespace = (realm, namespace) => {
     }
 
     return Toys.rootRealm(realm);
+};
+
+
+internals.setNamespaceFromRealm = (rootState, realm) => {
+
+    rootState.namespaces[realm.plugin] = rootState.namespaces[realm.plugin] || new Set();
+    rootState.namespaces[realm.plugin].add(realm);
+
+    return rootState;
 };
 
 internals.stop = async (server) => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,6 +8,7 @@ const Toys = require('toys');
 const Migrator = require('./migrator');
 const SchwiftyModel = require('./model');
 const Schema = require('./schema');
+const Helpers = require('./helpers');
 const Package = require('../package.json');
 
 const internals = {};
@@ -19,17 +20,15 @@ exports.migrationsStubPath = Path.join(__dirname, 'migration.stub');
 exports.assertCompatible = (A, B, msg) => {
 
     const isExtension = (A.prototype instanceof B) || (B.prototype instanceof A);
-    const nameA = internals.getName(A);
-    const nameB = internals.getName(B);
+    const nameA = Helpers.getName(A);
+    const nameB = Helpers.getName(B);
     const nameMatches = nameA === nameB;                  // Will appear by the same name on `server.models()` (plugin compat)
     const tablenameMatches = A.tableName === B.tableName; // Will touch the same table in the database (query compat)
 
     Hoek.assert(isExtension && nameMatches && tablenameMatches, msg || 'Models are incompatible.  One model must extend the other, they must have the same name, and share the same tableName.');
 };
 
-exports.name = Symbol('schwiftyName');
-
-exports.sandbox = Symbol('schwiftySandbox');
+exports.sandbox = Helpers.symbols.sandbox;
 
 exports.plugin = {
     pkg: Package,
@@ -101,8 +100,8 @@ internals.initialize = async (server) => {
 
         const knex = internals.knex(() => realm)();
         const BoundModel = (knex && !Model.knex()) ? Model.bindKnex(knex) : Model;
-        const name = internals.getName(Model);
-        const sandbox = internals.getSandbox(Model);
+        const name = Helpers.getName(Model);
+        const sandbox = Helpers.getSandbox(Model);
 
         collector.realmByModel.delete(Model);
         collector.realmByModel.set(BoundModel, realm);
@@ -129,8 +128,8 @@ internals.initialize = async (server) => {
             const modelInfo = [...collector.realmByModel]
                 .filter(([Model]) => Model.knex() === knex)
                 .map(([Model, realm]) => ({
-                    name: internals.getName(Model),
-                    sandbox: internals.getSandbox(Model),
+                    name: Helpers.getName(Model),
+                    sandbox: Helpers.getSandbox(Model),
                     namespace: realm.plugin
                 }));
 
@@ -204,8 +203,8 @@ internals.schwifty = (realm, config) => {
 
     config.models.forEach((Model) => {
 
-        const name = internals.getName(Model);
-        const sandbox = internals.getSandbox(Model);
+        const name = Helpers.getName(Model);
+        const sandbox = Helpers.getSandbox(Model);
 
         Hoek.assert(name, 'Every model class must have a name.');
         Hoek.assert(sandbox || !rootState.models[name], `Model "${name}" has already been registered.`);
@@ -266,7 +265,7 @@ internals.knex = (getRealm) => {
             knex = state.knex;
 
             // Skip any knexes outside the given namespace that are sandboxed
-            if (knex && internals.getSandbox(knex) && iterateRealm !== realm) {
+            if (knex && Helpers.getSandbox(knex) && iterateRealm !== realm) {
                 knex = null;
             }
 
@@ -324,23 +323,6 @@ internals.addModelToRealm = (realm, Model, name, { override = false } = {}) => {
     const state = internals.state(realm);
     Hoek.assert(override || !state.models[name], `A model named "${name}" has already been registered in plugin namespace "${realm.plugin}".`);
     state.models[name] = Model;
-};
-
-internals.getName = (Model) => Model[exports.name] || Model.name;
-
-internals.getSandbox = (obj) => {
-
-    const sandbox = obj[exports.sandbox];
-
-    if (sandbox === 'plugin') {
-        return true;
-    }
-
-    if (sandbox === 'server') {
-        return false;
-    }
-
-    return sandbox;
 };
 
 internals.state = (realm) => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,11 +19,17 @@ exports.migrationsStubPath = Path.join(__dirname, 'migration.stub');
 exports.assertCompatible = (A, B, msg) => {
 
     const isExtension = (A.prototype instanceof B) || (B.prototype instanceof A);
-    const nameMatches = A.name === B.name;                // Will appear by the same name on `server.models()` (plugin compat)
+    const nameA = internals.getName(A);
+    const nameB = internals.getName(B);
+    const nameMatches = nameA === nameB;                  // Will appear by the same name on `server.models()` (plugin compat)
     const tablenameMatches = A.tableName === B.tableName; // Will touch the same table in the database (query compat)
 
     Hoek.assert(isExtension && nameMatches && tablenameMatches, msg || 'Models are incompatible.  One model must extend the other, they must have the same name, and share the same tableName.');
 };
+
+exports.name = Symbol('schwiftyName');
+
+exports.sandbox = Symbol('schwiftySandbox');
 
 exports.plugin = {
     pkg: Package,
@@ -100,12 +106,16 @@ internals.initialize = async (server) => {
 
         const knex = internals.knex(() => realm)();
         const BoundModel = (knex && !Model.knex()) ? Model.bindKnex(knex) : Model;
+        const name = internals.getName(Model);
+        const sandbox = internals.getSandbox(Model);
+
+        if (sandbox) {
+            return internals.addModelToRealm(realm, BoundModel, name, { override: true });
+        }
 
         Toys.forEachAncestorRealm(realm, (r) => {
 
-            const s = internals.state(r);
-
-            s.models[Model.name] = BoundModel;
+            internals.addModelToRealm(r, BoundModel, name, { override: true });
         });
     });
 
@@ -121,7 +131,7 @@ internals.initialize = async (server) => {
             const models = internals.models(() => server.realm)(true);
             const modelNames = Object.values(models)
                 .filter((Model) => Model.knex() === knex)
-                .map((Model) => Model.name);
+                .map(internals.getName);
 
             // Augment original error message
 
@@ -191,28 +201,23 @@ internals.schwifty = (realm, config) => {
 
     config.models.forEach((Model) => {
 
-        Hoek.assert(Model.name, 'Every model class must have a name.');
-        Hoek.assert(!rootState.models || !rootState.models[Model.name], `Model "${Model.name}" has already been registered.`);
+        const name = internals.getName(Model);
+        const sandbox = internals.getSandbox(Model);
 
+        Hoek.assert(name, 'Every model class must have a name.');
+        Hoek.assert(sandbox || !rootState.models[name], `Model "${name}" has already been registered.`);
+
+        rootState.namespaces[realm.plugin] = rootState.namespaces[realm.plugin] || new Set();
+        rootState.namespaces[realm.plugin].add(realm);
         rootState.collector.realmByModel.set(Model, realm);
-    });
 
-    Toys.forEachAncestorRealm(realm, (r) => {
-
-        const s = internals.state(r);
-
-        if (!s.exists) {
-            Object.assign(s, {
-                exists: true,
-                models: {},
-                migrationsDir: null,    // If present, will be resolved to an absolute path
-                knex: null
-            });
+        if (sandbox) {
+            return internals.addModelToRealm(realm, Model, name);
         }
 
-        config.models.forEach((Model) => {
+        Toys.forEachAncestorRealm(realm, (r) => {
 
-            s.models[Model.name] = Model;
+            internals.addModelToRealm(r, Model, name);
         });
     });
 
@@ -249,13 +254,21 @@ internals.knex = (getRealm) => {
 
     return function () {
 
-        let knex;
-        let realm = getRealm(this);
+        const realm = getRealm(this);
 
-        while (!knex && realm) {
-            const state = internals.state(realm);
+        let knex;
+        let iterateRealm = realm;
+
+        while (!knex && iterateRealm) {
+
+            const state = internals.state(iterateRealm);
+
             knex = state.knex;
-            realm = realm.parent;
+            if (knex && internals.getSandbox(knex) && iterateRealm !== realm) {
+                knex = null;
+            }
+
+            iterateRealm = iterateRealm.parent;
         }
 
         return knex || null;
@@ -278,5 +291,49 @@ internals.stop = async (server) => {
     );
 };
 
-internals.state = (realm) => Toys.state(realm, 'schwifty');
-internals.rootState = (realm) => Toys.rootState(realm, 'schwifty');
+internals.addModelToRealm = (realm, Model, name, { override = false } = {}) => {
+
+    const state = internals.state(realm);
+    Hoek.assert(override || !state.models[name], `A model named "${name}" has already been registered in plugin namespace "${realm.plugin}".`);
+    state.models[name] = Model;
+};
+
+internals.getName = (Model) => Model[exports.name] || Model.name;
+
+internals.getSandbox = (obj) => {
+
+    const sandbox = obj[exports.sandbox];
+
+    if (sandbox === 'plugin') {
+        return true;
+    }
+
+    if (sandbox === 'server') {
+        return false;
+    }
+
+    return sandbox;
+};
+
+internals.state = (realm) => {
+
+    const state = Toys.state(realm, 'schwifty');
+
+    if (Object.keys(state).length === 0) {
+        Object.assign(state, {
+            models: {},
+            migrationsDir: null,    // If present, will be resolved to an absolute path
+            knex: null,
+            namespaces: {}
+        });
+    }
+
+    return state;
+};
+
+internals.rootState = (realm) => {
+
+    const rootRealm = Toys.rootRealm(realm);
+
+    return internals.state(rootRealm);
+};

--- a/lib/model.js
+++ b/lib/model.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const Objection = require('objection');
+const Helpers = require('./helpers');
 
 const internals = {};
 
@@ -11,12 +12,53 @@ module.exports = class SchwiftyModel extends Objection.Model {
         return new internals.Validator();
     }
 
+    // Used by objection for bindKnex() caching
+    static uniqueTag(...args) {
+
+        if (!this.hasOwnProperty('$$schwiftyUniqueId')) {
+            Helpers.setNonEnumerableProperty(
+                this,
+                '$$schwiftyUniqueId',
+                ++SchwiftyModel.$$schwiftyUniqueCounter
+            );
+        }
+
+        // Based on the model name and table name
+        let uniqueTag = super.uniqueTag(...args);
+
+        if (Helpers.getSandbox(this)) {
+            uniqueTag += `_id:${this.$$schwiftyUniqueId}`;
+        }
+
+        return uniqueTag;
+    }
+
+    static bindKnex(...args) {
+
+        const BoundModel = super.bindKnex(...args);
+
+        Helpers.copyDescriptor('$$schwiftyUniqueId', this, BoundModel);
+        Helpers.copyDescriptor(Helpers.symbols.sandbox, this, BoundModel);
+
+        return BoundModel;
+    }
+
+    static bindTransaction(...args) {
+
+        const BoundModel = super.bindTransaction(...args);
+
+        Helpers.copyDescriptor('$$schwiftyUniqueId', this, BoundModel);
+        Helpers.copyDescriptor(Helpers.symbols.sandbox, this, BoundModel);
+
+        return BoundModel;
+    }
+
     // Caches schema, with and without optional keys
     // Will create $$joiSchema and $$joiSchemaPatch properties
     static getJoiSchema(patch) {
 
         if (!this.hasOwnProperty('$$joiSchema')) {
-            internals.setNonEnumerableProperty(
+            Helpers.setNonEnumerableProperty(
                 this,
                 '$$joiSchema',
                 this.joiSchema
@@ -27,7 +69,7 @@ module.exports = class SchwiftyModel extends Objection.Model {
 
         if (patch) {
             if (!this.hasOwnProperty('$$joiSchemaPatch')) {
-                internals.setNonEnumerableProperty(
+                Helpers.setNonEnumerableProperty(
                     this,
                     '$$joiSchemaPatch',
                     internals.patchSchema(schema)
@@ -89,13 +131,15 @@ module.exports = class SchwiftyModel extends Objection.Model {
     // Behold.
     static set jsonAttributes(value) {
 
-        internals.setNonEnumerableProperty(
+        Helpers.setNonEnumerableProperty(
             this,
             '$$schwiftyJsonAttributes',
             value
         );
     }
 };
+
+Helpers.setNonEnumerableProperty(module.exports, '$$schwiftyUniqueCounter', 0);
 
 internals.Validator = class SchwiftyValidator extends Objection.Validator {
 
@@ -131,16 +175,6 @@ internals.Validator = class SchwiftyValidator extends Objection.Validator {
 
         return validation.value;
     }
-};
-
-internals.setNonEnumerableProperty = (obj, prop, value) => {
-
-    Object.defineProperty(obj, prop, {
-        enumerable: false,
-        writable: true,
-        configurable: true,
-        value
-    });
 };
 
 internals.patchSchema = (schema) => {

--- a/lib/model.js
+++ b/lib/model.js
@@ -240,7 +240,7 @@ internals.copyProperties = (SourceModel, TargetModel) => {
 
 internals.hoistModelProperties = [
     Helpers.symbols.sandbox,
-    '$$schwiftyUnique',
+    '$$schwiftyUniqueId',
     '$$joiSchema',
     '$$joiSchemaPatch',
     '$$schwiftyJsonAttributes'

--- a/lib/model.js
+++ b/lib/model.js
@@ -23,10 +23,16 @@ module.exports = class SchwiftyModel extends Objection.Model {
             );
         }
 
-        // Based on the model name and table name
+        // Typically "{table-name}_{model-name}"
         let uniqueTag = super.uniqueTag(...args);
 
         if (Helpers.getSandbox(this)) {
+            // We need to provide an id because it's possible that a sandboxed
+            // model might have the same model name and table name (i.e. same unique tag)
+            // as another model on the server. That works great in schwifty/hapi, but
+            // does not work nicely with objection's bindKnex() cache. We additionally
+            // copy the same $$schwiftyUniqueId to the bound model (within bindKnex() and
+            // bindTransaction()) so that bound models remain indistiguishable from unbound models.
             uniqueTag += `_id:${this.$$schwiftyUniqueId}`;
         }
 
@@ -37,20 +43,14 @@ module.exports = class SchwiftyModel extends Objection.Model {
 
         const BoundModel = super.bindKnex(...args);
 
-        Helpers.copyDescriptor('$$schwiftyUniqueId', this, BoundModel);
-        Helpers.copyDescriptor(Helpers.symbols.sandbox, this, BoundModel);
-
-        return BoundModel;
+        return internals.copyProperties(this, BoundModel);
     }
 
     static bindTransaction(...args) {
 
         const BoundModel = super.bindTransaction(...args);
 
-        Helpers.copyDescriptor('$$schwiftyUniqueId', this, BoundModel);
-        Helpers.copyDescriptor(Helpers.symbols.sandbox, this, BoundModel);
-
-        return BoundModel;
+        return internals.copyProperties(this, BoundModel);
     }
 
     // Caches schema, with and without optional keys
@@ -222,3 +222,26 @@ internals.parseJoiValidationError = (validation, Model) => {
     // just handles creating a standard ValidationError
     return Model.createValidationError(validationInfo);
 };
+
+internals.copyProperties = (SourceModel, TargetModel) => {
+
+    if (!TargetModel.hasOwnProperty('$$schwiftyBound')) {
+
+        internals.hoistModelProperties.forEach((property) => {
+
+            Helpers.copyDescriptor(property, SourceModel, TargetModel);
+        });
+
+        Helpers.setNonEnumerableProperty(TargetModel, '$$schwiftyBound', true);
+    }
+
+    return TargetModel;
+};
+
+internals.hoistModelProperties = [
+    Helpers.symbols.sandbox,
+    '$$schwiftyUnique',
+    '$$joiSchema',
+    '$$joiSchemaPatch',
+    '$$schwiftyJsonAttributes'
+];

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@hapi/hapi-19": "npm:@hapi/hapi@19",
     "@hapi/lab": "20.x.x",
     "@hapi/somever": "2.x.x",
+    "ahem": "1.x.x",
     "coveralls": "3.x.x",
     "knex": "0.20.x",
     "objection": "2.x.x",

--- a/test/index.js
+++ b/test/index.js
@@ -814,6 +814,29 @@ describe('Schwifty', () => {
             expect(plugin.models().Dog.knex()).to.shallow.equal(knex);
         });
 
+        it('does not bind knex instance to model when Schwifty.bindKnex property is false.', async () => {
+
+            const knex = makeKnex();
+            const server = await getServer({ knex });
+
+            const plugin = await getPlugin(server, 'plugin');
+            plugin.schwifty(TestModels.Person);
+            plugin.schwifty(class Dog extends TestModels.Dog {
+                static get [Schwifty.bindKnex]() {
+
+                    return false;
+                }
+            });
+
+            expect(server.models().Person.knex()).to.not.exist();
+            expect(plugin.models().Dog.knex()).to.not.exist();
+
+            await server.initialize();
+
+            expect(server.models().Person.knex()).to.shallow.equal(knex);
+            expect(plugin.models().Dog.knex()).to.not.exist();
+        });
+
         it('binds root knex instance to plugins\' models by default.', async () => {
 
             const knex = makeKnex();


### PR DESCRIPTION
This PR implements namespacing and sandboxing (resolves #84) and opting out of automatic knex binding during server initialization (resolves #85).

The below is partially adapted from the description of the analogous features in https://github.com/hapipal/schmervice/pull/10.

Namespaces are an extension to the ability to pass `true` to `server.models(true)` in order to access all models (from the perspective of the root server). Now you may also pass a plugin name as a string `server.models('my-plugin')` in order to access models from the perspective of that plugin. In other words, calling `server.models()` inside `my-plugin` is the same as calling `server.models('my-plugin')` from _any_ plugin; identically calling `server.models()` on the root server is the same as calling `server.models(true)` from any plugin.

Sandboxing is a mechanism to opt-out of models being available to all ancestor plugins/namespaces of the plugin that registered the model. This essentially is the schwifty-y way of having models that are "private" within the plugin that registered them.  This works by setting the `Schwifty.sandbox` symbol to `true` on a model or knex instance.

These features work together to enable better plugin encapsulation and greater testability, with the ability to not only access, but also mock-out models on a per-plugin basis.  These features also apply to knex instances accessed with `server.knex()`.

Sandboxing adds some complexity to the base schwifty `Model` class in order to fully support sandboxing when there are multiple models that have the same name.  Objection has an internal model caching mechanism as a critical performance optimization to `bindKnex()` and `bindTransaction()`.  Models are cached internally to objection per knex instance by their  `name` and `tableName`.  The custom implementation of `static uniqueTag()` allows us to control this caching behavior.  It allows us to support abstractions where one plugin might use a sandboxed model and another plugin might extend that model with its own methods, fields, etc.  Both are totally useful, valid models— one is simply more specific!

The ability to opt-out of automatic knex binding during server start is an important escape hatch for applications that have more custom needs.  For example, it may be useful when some models are multi-tenant and need to be bound to a connection lazily, e.g. per request or per query.  This works by setting the `Schwifty.bindKnex` symbol to `false` on a model.