### PR TITLE
Dependency update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 import:
-  - hapipal/ci-config-travis:hapi_all.yml@hapi-v21
-  - hapipal/ci-config-travis:node_js.yml@hapi-v21
+  - source: hapipal/ci-config-travis:node_js.yml@node-v16-min
+  - source: hapipal/ci-config-travis:hapi_all.yml@node-v16-min

--- a/API.md
+++ b/API.md
@@ -4,7 +4,7 @@ A model layer for [hapi](https://hapi.dev) integrating [Objection ORM](https://v
 
 > **Note**
 >
-> Schwifty is intended for use with hapi v19+, nodejs v12+, Joi v17+, Objection v1 through v3, and knex v0.16+ (_see v5 for lower support_).
+> Schwifty is intended for use with hapi v20+, nodejs v16+, Joi v17+, Objection v2 through v3, and knex v0.21.19+ (_see v6 for lower support_).
 
 ## The hapi plugin
 ### Registration

--- a/API.md
+++ b/API.md
@@ -4,7 +4,7 @@ A model layer for [hapi](https://hapi.dev) integrating [Objection ORM](https://v
 
 > **Note**
 >
-> Schwifty is intended for use with hapi v20+, nodejs v16+, Joi v17+, Objection v2 through v3, and knex v0.21.19+ (_see v6 for lower support_).
+> Schwifty is intended for use with hapi v20+, nodejs v16+, Joi v17, Objection v3, and knex v2 (_see v6 for lower support_).
 
 ## The hapi plugin
 ### Registration

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ npm install @hapipal/schwifty
 ## Usage
 > See also the [API Reference](API.md)
 >
-> Schwifty is intended for use with hapi v19+, nodejs v12+, Joi v17+, Objection v1 through v3, and knex v0.16+ (_see v5 for lower support_).
+> Schwifty is intended for use with hapi v20+, nodejs v16+, Joi v17+, Objection v2 through v3, and knex v0.21.19+ (_see v6 for lower support_).
 
 Schwifty is used to define [Joi](https://joi.dev/)-compatible models and knex connections for use with Objection ORM.  Those models then become available within your hapi server where it is most convenient.  It has been tailored to multi-plugin deployments, where each plugin may set clear boundaries in defining its own models, knex database connections, and migrations.  It's safe to register schwifty multiple times, wherever you'd like to use it, as it protects against model name collisions and other ambiguous configurations.
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ npm install @hapipal/schwifty
 ## Usage
 > See also the [API Reference](API.md)
 >
-> Schwifty is intended for use with hapi v20+, nodejs v16+, Joi v17+, Objection v2 through v3, and knex v0.21.19+ (_see v6 for lower support_).
+> Schwifty is intended for use with hapi v20+, nodejs v16+, Joi v17, Objection v3, and knex v2 (_see v6 for lower support_).
 
 Schwifty is used to define [Joi](https://joi.dev/)-compatible models and knex connections for use with Objection ORM.  Those models then become available within your hapi server where it is most convenient.  It has been tailored to multi-plugin deployments, where each plugin may set clear boundaries in defining its own models, knex database connections, and migrations.  It's safe to register schwifty multiple times, wherever you'd like to use it, as it protects against model name collisions and other ambiguous configurations.
 

--- a/package.json
+++ b/package.json
@@ -29,14 +29,14 @@
   ],
   "dependencies": {
     "@hapi/hoek": "^11.0.2",
-    "@hapipal/toys": "^3.2.0",
+    "@hapipal/toys": "^4.0.0",
     "joi": "^17.8.3"
   },
   "peerDependencies": {
     "@hapi/hapi": ">=20 <22",
-    "joi": ">=17 <18",
-    "knex": ">=0.21.19",
-    "objection": ">=2 <4"
+    "joi": "^17.0.0",
+    "knex": "^2.0.0",
+    "objection": "^3.0.0"
   },
   "devDependencies": {
     "@hapi/code": "^9.0.3",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "homepage": "https://github.com/hapipal/schwifty#readme",
   "engines": {
-    "node": ">=12"
+    "node": ">=16"
   },
   "keywords": [
     "hapi",
@@ -28,25 +28,25 @@
     "model"
   ],
   "dependencies": {
-    "@hapi/hoek": "^9.0.0",
+    "@hapi/hoek": "^11.0.2",
     "@hapipal/toys": "^3.2.0",
-    "joi": "^17.0.0"
+    "joi": "^17.8.3"
   },
   "peerDependencies": {
-    "@hapi/hapi": ">=19 <22",
+    "@hapi/hapi": ">=20 <22",
     "joi": ">=17 <18",
-    "knex": ">=0.16",
-    "objection": ">=1 <4"
+    "knex": ">=0.21.19",
+    "objection": ">=2 <4"
   },
   "devDependencies": {
-    "@hapi/code": "^8.0.0",
-    "@hapi/hapi": "^20.0.0",
-    "@hapi/lab": "^24.0.0",
-    "@hapipal/ahem": "^2.0.0",
-    "coveralls": "^3.0.0",
-    "knex": "^0.95.0",
-    "objection": "^3.0.0",
-    "sqlite3": "^5.0.0"
+    "@hapi/code": "^9.0.3",
+    "@hapi/hapi": "^21.3.0",
+    "@hapi/lab": "^25.1.2",
+    "@hapipal/ahem": "^2.1.0",
+    "coveralls": "^3.1.1",
+    "knex": "^2.4.2",
+    "objection": "^3.0.1",
+    "sqlite3": "^5.1.4"
   },
   "author": "William Woodruff and Contributors",
   "license": "MIT"


### PR DESCRIPTION
Drop support for older versions of node and bump peer deps accordingly.

Tests were failing with the old min versions of objection/knex from the peer deps, so I updated until I had what seem to be the min versions of each that will play nice with each other and still have all tests passing.